### PR TITLE
Gamemodes for MatchTeams

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
@@ -4,10 +4,12 @@ import com.google.gson.*;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
 import network.warzone.tgm.nickname.ProfileCache;
+import network.warzone.tgm.util.Strings;
 import network.warzone.warzoneapi.models.Author;
 import network.warzone.warzoneapi.models.MojangProfile;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -56,10 +58,11 @@ public class MapInfoDeserializer implements JsonDeserializer<MapInfo> {
             String teamId = teamJson.get("id").getAsString();
             String teamName = teamJson.get("name").getAsString();
             ChatColor teamColor = ChatColor.valueOf(teamJson.get("color").getAsString().toUpperCase().replace(" ", "_"));
+            GameMode teamGamemode = teamJson.has("gamemode") ? GameMode.valueOf(Strings.getTechnicalName(teamJson.get("gamemode").getAsString())) : GameMode.SURVIVAL;
             int teamMax = teamJson.get("max").getAsInt();
             int teamMin = teamJson.get("min").getAsInt();
             boolean friendlyFire = teamJson.has("friendlyFire") && teamJson.get("friendlyFire").getAsBoolean();
-            parsedTeams.add(new ParsedTeam(teamId, teamName, teamColor, teamMax, teamMin, friendlyFire));
+            parsedTeams.add(new ParsedTeam(teamId, teamName, teamColor, teamGamemode, teamMax, teamMin, friendlyFire));
         }
 
         return new MapInfo(name, version, authors, gameType, parsedTeams, json);

--- a/TGM/src/main/java/network/warzone/tgm/map/ParsedTeam.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/ParsedTeam.java
@@ -3,6 +3,7 @@ package network.warzone.tgm.map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 
 /**
  * Created by luke on 4/27/17.
@@ -12,6 +13,7 @@ public class ParsedTeam {
     private String id;
     private String alias;
     private ChatColor teamColor;
+    private GameMode teamGamemode;
     private int max;
     private int min;
     private boolean friendlyFire;

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
@@ -75,7 +75,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
             playerContext.getPlayer().setAllowFlight(true);
             playerContext.getPlayer().setFlying(true);
             playerContext.getPlayer().teleport(getTeamSpawn(matchTeam).getLocation());
-            if (!matchTeam.isSpectator() && !gameType.equals(GameType.Infected)) playerContext.getPlayer().setGameMode(GameMode.SURVIVAL);
+            if (!matchTeam.isSpectator() && !gameType.equals(GameType.Infected)) playerContext.getPlayer().setGameMode(matchTeam.getGamemode());
         }
         if (gameClassModule != null) {
             Bukkit.getScheduler().runTaskLater(TGM.get(), () -> {

--- a/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
@@ -289,7 +289,7 @@ public class FFAModule extends MatchModule implements Listener {
         ScoreboardManagerModule scoreboardManagerModule = match.getModule(ScoreboardManagerModule.class);
 
         if (this.teamManagerModule.getTeamByAlias("winner") == null) {
-            this.teamManagerModule.addTeam(new MatchTeam("winner", player, ChatColor.YELLOW, false, 0, 1, true));
+            this.teamManagerModule.addTeam(new MatchTeam("winner", player, ChatColor.YELLOW, GameMode.SURVIVAL, false, 0, 1, true));
             TGM.get().getPlayerManager().getPlayers().forEach(playerContext -> {
                 scoreboardManagerModule.registerScoreboardTeam(
                         scoreboardManagerModule.getScoreboard(playerContext.getPlayer()),

--- a/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ public class MatchTeam {
     private final String id;
     @Setter private String alias;
     private ChatColor color;
+    private GameMode gamemode;
     private final boolean spectator;
     @Setter private int max;
     @Setter private int min;

--- a/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
@@ -12,6 +12,7 @@ import network.warzone.tgm.match.ModuleLoadTime;
 import network.warzone.tgm.user.PlayerContext;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -36,13 +37,14 @@ public class TeamManagerModule extends MatchModule implements Listener {
 
     @Override
     public void load(Match match) {
-        teams.add(new MatchTeam("spectators", "Spectators", ChatColor.AQUA, true,  Integer.MAX_VALUE, 0, false));
+        teams.add(new MatchTeam("spectators", "Spectators", ChatColor.AQUA, GameMode.ADVENTURE, true,  Integer.MAX_VALUE, 0, false));
 
         for (ParsedTeam parsedTeam : match.getMapContainer().getMapInfo().getTeams()) {
             teams.add(new MatchTeam(
                     parsedTeam.getId(),
                     parsedTeam.getAlias(),
                     parsedTeam.getTeamColor(),
+                    parsedTeam.getTeamGamemode(),
                     false,
                     parsedTeam.getMax(),
                     parsedTeam.getMin(),


### PR DESCRIPTION
Resolves #68 

Adds `gamemode` field for teams.
```json
{
  "teams": [
    {
      "id": "cyan",
      "name": "Cyan",
      "color": "dark aqua",
      "gamemode": "creative",
      "min": 1,
      "max": 40
    }
  ]
}
```
