### PR TITLE
Allows whitespace for map names in rotation file

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/MapRotationFile.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapRotationFile.java
@@ -47,7 +47,7 @@ public class MapRotationFile implements MapRotation {
             List<String> lines = Files.readLines(rotationFile, Charset.defaultCharset());
             for (String line : lines) {
                 for (MapContainer mapContainer : mapLibrary.getMaps()) {
-                    if (mapContainer.getMapInfo().getName().equalsIgnoreCase(line)) {
+                    if (mapContainer.getMapInfo().getName().equalsIgnoreCase(line.trim())) {
                         rotation.add(mapContainer);
                     }
                 }


### PR DESCRIPTION
i.e.: 'Timeless ' would be recognized whereas before it wouldn't of