### PR TITLE
Update punishment broadcast

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -6,7 +6,9 @@ import network.warzone.tgm.TGM;
 import network.warzone.tgm.modules.chat.ChatConstant;
 import network.warzone.tgm.modules.reports.Report;
 import network.warzone.tgm.modules.reports.ReportsModule;
+import network.warzone.tgm.nickname.NickManager;
 import network.warzone.tgm.user.PlayerContext;
+import network.warzone.tgm.util.HashMaps;
 import network.warzone.tgm.util.TimeUnitPair;
 import network.warzone.tgm.util.itemstack.ItemFactory;
 import network.warzone.tgm.util.menu.ConfirmMenu;
@@ -472,7 +474,8 @@ public class PunishCommands {
                     if (response.isKickable()) {
                         kickPlayer(response.getPunishment(), response.getName());
                     }
-                    broadcastPunishment(response.getName(), response.getIp(), punisher.getName().replace("CONSOLE", "Console"), verb, timeUnitPair, reason, time, broadcast);
+
+                    broadcastPunishment(response.getName(), response.getIp(), TGM.get().getNickManager().getOriginalName(punisher.getName()).replace("CONSOLE", "Console"), verb, timeUnitPair, reason, time, broadcast);
                     Player target;
                     if (response.getName() != null && (target = Bukkit.getPlayer(response.getName())) != null) {
                         TGM.get().getPlayerManager().getPlayerContext(target).getUserProfile().addPunishment(response.getPunishment());

--- a/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
@@ -16,6 +16,7 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.visibility.VisibilityController;
 import network.warzone.tgm.modules.visibility.VisibilityControllerImpl;
 import network.warzone.tgm.user.PlayerContext;
+import network.warzone.tgm.util.HashMaps;
 import network.warzone.warzoneapi.models.MojangProfile;
 import network.warzone.warzoneapi.models.Rank;
 import network.warzone.warzoneapi.models.Skin;
@@ -63,6 +64,15 @@ public class NickManager {
 
             queuedNicks.add(new QueuedNick(newName, skin, player));
         });
+    }
+
+    public String getOriginalName(String username) {
+        if (nickNames.containsValue(username)) {
+            UUID uuid = HashMaps.reverseGetFirst(username, nickNames);
+            return originalNames.get(uuid);
+        } else {
+            return username;
+        }
     }
 
     public Optional<QueuedNick> getQueuedNick(Player player) {


### PR DESCRIPTION
Updates the punishment broadcast so whenever a nicked staff member punishes a player, it will broadcast the original name. Has been tested, works fine.