### PR TITLE
Breaking blocks after matches

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -40,10 +40,12 @@ public class MatchResultModule extends MatchModule implements Listener {
 
             Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
 
+            Bukkit.broadcastMessage(TGM.get().getConfig().getConfigurationSection("server").getBoolean("post-block-break") + "horse");
+
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                if (TGM.get().getConfig().getBoolean("post-block-break") && event.getPlayer().hasPermission("tgm.post.break")) {
+                if (TGM.get().getConfig().getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
                     player.setGameMode(GameMode.CREATIVE);
                 } else {
                     player.setGameMode(GameMode.ADVENTURE);

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -43,7 +43,7 @@ public class MatchResultModule extends MatchModule implements Listener {
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                if (TGM.get().getConfig().getConfigurationSection("map").getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
+                if (TGM.get().getConfig().getBoolean("map.post-block-break", false) && player.hasPermission("tgm.post.break")) {
                     player.setGameMode(GameMode.SURVIVAL);
                 } else {
                     player.setGameMode(GameMode.ADVENTURE);

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -43,7 +43,7 @@ public class MatchResultModule extends MatchModule implements Listener {
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                player.setGameMode(GameMode.ADVENTURE);
+                player.setGameMode(GameMode.CREATIVE);
                 player.setAllowFlight(true);
                 player.setVelocity(player.getVelocity().setY(1.0)); // Weeee!
                 player.setFlying(true);

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -40,12 +40,10 @@ public class MatchResultModule extends MatchModule implements Listener {
 
             Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
 
-            Bukkit.broadcastMessage(TGM.get().getConfig().getConfigurationSection("server").getBoolean("post-block-break") + "horse");
-
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                if (TGM.get().getConfig().getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
+                if (TGM.get().getConfig().getConfigurationSection("server").getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
                     player.setGameMode(GameMode.CREATIVE);
                 } else {
                     player.setGameMode(GameMode.ADVENTURE);

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -43,8 +43,8 @@ public class MatchResultModule extends MatchModule implements Listener {
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                if (TGM.get().getConfig().getConfigurationSection("server").getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
-                    player.setGameMode(GameMode.CREATIVE);
+                if (TGM.get().getConfig().getConfigurationSection("map").getBoolean("post-block-break") && player.hasPermission("tgm.post.break")) {
+                    player.setGameMode(GameMode.SURVIVAL);
                 } else {
                     player.setGameMode(GameMode.ADVENTURE);
                 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -43,7 +43,11 @@ public class MatchResultModule extends MatchModule implements Listener {
             if (spectators.containsPlayer(player)) {
                 player.playSound(location, Sound.ENTITY_WITHER_DEATH, 1000, 1);
             } else {
-                player.setGameMode(GameMode.CREATIVE);
+                if (TGM.get().getConfig().getBoolean("post-block-break") && event.getPlayer().hasPermission("tgm.post.break")) {
+                    player.setGameMode(GameMode.CREATIVE);
+                } else {
+                    player.setGameMode(GameMode.ADVENTURE);
+                }
                 player.setAllowFlight(true);
                 player.setVelocity(player.getVelocity().setY(1.0)); // Weeee!
                 player.setFlying(true);

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -21,6 +21,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -241,8 +242,18 @@ public class SpectatorModule extends MatchModule implements Listener {
         if (teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
             event.setCancelled(true);
         }
-        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST && event.getPlayer().getGameMode() == GameMode.CREATIVE) {
+        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST && event.getPlayer().getGameMode() == GameMode.SURVIVAL) {
             event.setCancelled(false);
+        }
+    }
+
+    @EventHandler
+    public void onBlockDamage(BlockDamageEvent event) {
+        if (teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
+            event.setCancelled(true);
+        }
+        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST && event.getPlayer().getGameMode() == GameMode.SURVIVAL) {
+            event.setInstaBreak(true);
         }
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -238,7 +238,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onBreak(BlockBreakEvent event) {
-        if (isSpectating(event.getPlayer())) {
+        if (teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
             event.setCancelled(true);
         }
         if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST && event.getPlayer().getGameMode() == GameMode.CREATIVE) {
@@ -283,7 +283,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        if (isSpectating(event.getPlayer())) {
+        if (teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
             event.setCancelled(true);
             if (event.getItem() == null) return;
             if (event.getItem().isSimilar(teamSelectionItem)) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -241,6 +241,9 @@ public class SpectatorModule extends MatchModule implements Listener {
         if (isSpectating(event.getPlayer())) {
             event.setCancelled(true);
         }
+        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST && event.getPlayer().getGameMode() == GameMode.CREATIVE) {
+            event.setCancelled(false);
+        }
     }
 
     @EventHandler

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -52,3 +52,6 @@ server:
   # Text displayed after the match time on the tablist header.
   # Default: &f&lWARZONE
   tablist-name: "&f&lWARZONE"
+  # If players will be placed in to creative after te game is ended
+  # Any player is creative mode may break blocks during post game
+  post-block-break: false

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -52,6 +52,6 @@ server:
   # Text displayed after the match time on the tablist header.
   # Default: &f&lWARZONE
   tablist-name: "&f&lWARZONE"
-  # If players will be placed in to creative after te game is ended
+  # If players will be placed in to creative after the game is ended
   # Any player is creative mode may break blocks during post game
   post-block-break: false

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -28,6 +28,9 @@ chat:
     # Default: "&cChat is currently disabled."
     muted: "&cChat is currently disabled."
 map:
+  # If players will be placed in to survival after the game is ended
+  # Any player in survival mode may break blocks during post game
+  post-block-break: false
   # Retrieve map author names from the Mojang API using the UUIDs specified in the map.json.
   # Recommended for production use only.
   # Default: false
@@ -52,6 +55,3 @@ server:
   # Text displayed after the match time on the tablist header.
   # Default: &f&lWARZONE
   tablist-name: "&f&lWARZONE"
-  # If players will be placed in to creative after the game is ended
-  # Any player is creative mode may break blocks during post game
-  post-block-break: false


### PR DESCRIPTION
If enabled, users with a permission (tgm.post.break) will be set into survival mode and will be able to break any block. tqnk helped a lot with this pr

Resolves #607 