### PR TITLE
don't show offline nicked players

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class NickCommands {
 
-    @Command(aliases = {"nicks"}, desc = "View all nicked players")
+    @Command(aliases = {"nicks"}, desc = "View all online nicked players")
     @CommandPermissions({"tgm.command.whois"})
     public static void nicks(CommandContext cmd, CommandSender sender) {
         HashMap<UUID, String> originalNames = TGM.get().getNickManager().getOriginalNames();
@@ -36,13 +36,15 @@ public class NickCommands {
         StringBuilder message = new StringBuilder(ChatColor.YELLOW + "Nicked Players:");
 
         originalNames.forEach((uuid, originalName) -> {
-            message.append("\n")
+            if !(Bukkit.getPlayer(nickNames.get(uuid))) {
+                message.append("\n")
                     .append(ChatColor.DARK_PURPLE)
                     .append(originalName)
                     .append(ChatColor.GRAY)
                     .append(" is nicked as ")
                     .append(ChatColor.LIGHT_PURPLE)
                     .append(nickNames.get(uuid));
+            }
         });
 
         sender.sendMessage(message.toString());


### PR DESCRIPTION
This resolves #613 
Running /nicks now shows online nicked players. Personally, I don't think we need this. (maybe it could be a config option?) **testing in a few minutes, i'll comment the results**