### PR TITLE
Adds Redeemables, Bases, Flags, Pattern deserializer, and CTF Gamemode 

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/TGM.java
+++ b/TGM/src/main/java/network/warzone/tgm/TGM.java
@@ -21,6 +21,7 @@ import network.warzone.tgm.modules.GameRuleModule;
 import network.warzone.tgm.modules.killstreak.Killstreak;
 import network.warzone.tgm.modules.killstreak.KillstreakDeserializer;
 import network.warzone.tgm.nickname.NickManager;
+import network.warzone.tgm.parser.banner.BannerPatternsDeserializer;
 import network.warzone.tgm.parser.effect.EffectDeserializer;
 import network.warzone.tgm.parser.item.ItemDeserializer;
 import network.warzone.tgm.player.PlayerManager;
@@ -31,6 +32,7 @@ import network.warzone.warzoneapi.client.http.HttpClientConfig;
 import network.warzone.warzoneapi.client.offline.OfflineClient;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.banner.Pattern;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
@@ -89,6 +91,7 @@ public class TGM extends JavaPlugin {
                 // Bukkit
                 .registerTypeAdapter(ItemStack.class, new ItemDeserializer())
                 .registerTypeAdapter(PotionEffect.class, new EffectDeserializer())
+                .registerTypeAdapter(Pattern[].class, new BannerPatternsDeserializer())
 
                 .create();
 

--- a/TGM/src/main/java/network/warzone/tgm/TGM.java
+++ b/TGM/src/main/java/network/warzone/tgm/TGM.java
@@ -91,7 +91,6 @@ public class TGM extends JavaPlugin {
                 // Bukkit
                 .registerTypeAdapter(ItemStack.class, new ItemDeserializer())
                 .registerTypeAdapter(PotionEffect.class, new EffectDeserializer())
-                .registerTypeAdapter(Pattern[].class, new BannerPatternsDeserializer())
 
                 .create();
 

--- a/TGM/src/main/java/network/warzone/tgm/gametype/CTFManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/gametype/CTFManifest.java
@@ -1,0 +1,17 @@
+package network.warzone.tgm.gametype;
+
+import network.warzone.tgm.match.MatchManifest;
+import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.modules.ctf.CTFModule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CTFManifest extends MatchManifest {
+    @Override
+    public List<MatchModule> allocateGameModules() {
+        List<MatchModule> matchModules = new ArrayList<>();
+        matchModules.add(new CTFModule());
+        return matchModules;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/gametype/GameType.java
+++ b/TGM/src/main/java/network/warzone/tgm/gametype/GameType.java
@@ -14,7 +14,8 @@ public enum GameType {
     CTW("Capture the Wool", CTWManifest.class),
     Infected("Infection", InfectionManifest.class),
     Blitz("Blitz", BlitzManifest.class),
-    FFA("FFA", FFAManifest.class);
+    FFA("FFA", FFAManifest.class),
+    CTF("CTF", CTFManifest.class);
 
     private String name;
     private Class manifest;

--- a/TGM/src/main/java/network/warzone/tgm/modules/ItemRemoveModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ItemRemoveModule.java
@@ -16,6 +16,7 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class ItemRemoveModule extends MatchModule implements Listener {
@@ -26,6 +27,10 @@ public class ItemRemoveModule extends MatchModule implements Listener {
 
     public void add(Material material) {
         this.removed.add(material);
+    }
+
+    public void addAll(Collection<Material> materials) {
+        removed.addAll(materials);
     }
 
     public void remove(Material material) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
@@ -2,17 +2,30 @@ package network.warzone.tgm.modules.base;
 
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Redeemable redeemed by presence of an item
  * Created by yikes on 12/15/2019
  */
 public abstract class ItemRedeemable extends Redeemable {
+    private ItemStack redeemableItem;
+
+    /**
+     * Does the item in question match the item specified by the redeemable?
+     * @param item Item in question
+     * @return The answer
+     */
+    public boolean matchesRedeemable(Item item) {
+        return item.getItemStack().isSimilar(redeemableItem);
+    }
+
+
     /**
      * Called when the redeemable is redeemed, with dropped item
      * Criteria of player should be invalidated when this method is called
      *
      * @param player Player who has redeemed
      */
-    public abstract void redeem(Player player, Item item);
+    public abstract void redeem(Player player);
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
@@ -1,0 +1,18 @@
+package network.warzone.tgm.modules.base;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+
+/**
+ * Redeemable redeemed by presence of an item
+ * Created by yikes on 12/15/2019
+ */
+public abstract class ItemRedeemable extends Redeemable {
+    /**
+     * Called when the redeemable is redeemed, with dropped item
+     * Criteria of player should be invalidated when this method is called
+     *
+     * @param player Player who has redeemed
+     */
+    public abstract void redeem(Player player, Item item);
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/ItemRedeemable.java
@@ -1,6 +1,5 @@
 package network.warzone.tgm.modules.base;
 
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -16,8 +15,8 @@ public abstract class ItemRedeemable extends Redeemable {
      * @param item Item in question
      * @return The answer
      */
-    public boolean matchesRedeemable(Item item) {
-        return item.getItemStack().isSimilar(redeemableItem);
+    public boolean matchesRedeemable(ItemStack item) {
+        return item.isSimilar(redeemableItem);
     }
 
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
@@ -35,7 +35,6 @@ public class MatchBase implements Listener {
     private TeamManagerModule teamManagerModule;
     private List<PlayerRedeemable> playerRedeemables = new ArrayList<>();
     private List<ItemRedeemable> itemRedeemables = new ArrayList<>();
-    private Map<Item, BukkitTask> itemTasks = new HashMap<>();
 
     private RespawnModule respawnModule;
 
@@ -117,8 +116,6 @@ public class MatchBase implements Listener {
     }
 
     public void unload() {
-        for (BukkitTask task : itemTasks.values()) task.cancel();
-        itemTasks = null;
         playerRedeemables = null;
         itemRedeemables = null;
         TGM.unregisterEvents(this);

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
@@ -1,0 +1,87 @@
+package network.warzone.tgm.modules.base;
+
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchStatus;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base represents an area where a PlayerRedeemable can be redeemed
+ * Created by yikes on 12/15/2019
+ */
+public class MatchBase implements Listener {
+    private Location baseLocation;
+    private Match match;
+    private List<PlayerRedeemable> playerRedeemables = new ArrayList<>();
+    private List<ItemRedeemable> itemRedeemables = new ArrayList<>();
+
+    public MatchBase(Location baseLocation, List<? extends Redeemable> redeemables) {
+        this.baseLocation = baseLocation;
+        this.match = TGM.get().getMatchManager().getMatch();
+        for (Redeemable redeemable : redeemables) {
+            if (redeemable instanceof PlayerRedeemable) {
+                playerRedeemables.add((PlayerRedeemable) redeemable);
+            } else if (redeemable instanceof ItemRedeemable) {
+                itemRedeemables.add((ItemRedeemable) redeemable);
+            }
+        }
+        TGM.registerEvents(this);
+    }
+
+    private List<PlayerRedeemable> hasPlayerRedeemables(Player player) {
+        List<PlayerRedeemable> eligibleRedeemables = new ArrayList<>();
+        for (PlayerRedeemable playerRedeemable : playerRedeemables) {
+            if (playerRedeemable.hasRedeemable(player)) eligibleRedeemables.add(playerRedeemable);
+        }
+        return eligibleRedeemables;
+    }
+
+    private List<ItemRedeemable> hasItemRedeemables(Player player) {
+        List<ItemRedeemable> eligibleRedeemables = new ArrayList<>();
+        for (ItemRedeemable itemRedeemable : itemRedeemables) {
+            if (itemRedeemable.hasRedeemable(player)) eligibleRedeemables.add(itemRedeemable);
+        }
+        return eligibleRedeemables;
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (match.getMatchStatus() != MatchStatus.MID || event.getFrom().distanceSquared(baseLocation) > 1) return;
+        else {
+            List<PlayerRedeemable> eligiblePlayerRedeemables = hasPlayerRedeemables(event.getPlayer());
+            if (eligiblePlayerRedeemables.size() == 0) return;
+            redeemPlayerRedeemables(eligiblePlayerRedeemables, event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        if (match.getMatchStatus() != MatchStatus.MID || event.getItemDrop().getLocation().distanceSquared(baseLocation) > 1) return;
+        else {
+            List<ItemRedeemable> eligibleItemRedeemables = hasItemRedeemables(event.getPlayer());
+            if (eligibleItemRedeemables.size() == 0) return;
+            redeemItemRedeemables(eligibleItemRedeemables, event.getPlayer(), event.getItemDrop());
+        }
+    }
+
+    private void redeemPlayerRedeemables(List<PlayerRedeemable> filteredPlayerRedeemables, Player player) {
+        for (PlayerRedeemable playerRedeemable : filteredPlayerRedeemables) playerRedeemable.redeem(player);
+    }
+
+    private void redeemItemRedeemables(List<ItemRedeemable> filteredItemRedeemables, Player player, Item item) {
+        for (ItemRedeemable itemRedeemable : filteredItemRedeemables) itemRedeemable.redeem(player, item);
+    }
+
+    public void unload() {
+        TGM.unregisterEvents(this);
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/PlayerRedeemable.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/PlayerRedeemable.java
@@ -1,0 +1,18 @@
+package network.warzone.tgm.modules.base;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Redeemable redeemed by presence of a player
+ * Created by yikes on 12/15/2019
+ */
+public abstract class PlayerRedeemable extends Redeemable {
+    /**
+     * Called when the redeemable is redeemed
+     * Criteria of player should be invalidated when this method is called
+     *
+     * @param player Player who has redeemed
+     */
+    public abstract void redeem(Player player);
+
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/base/Redeemable.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/Redeemable.java
@@ -1,0 +1,17 @@
+package network.warzone.tgm.modules.base;
+
+import org.bukkit.entity.Player;
+
+/**
+ * A redeemable is an object a player redeems at a base
+ *
+ * Created by yikes on 12/15/2019
+ */
+public abstract class Redeemable {
+    /**
+     * Checks if player has the redeemable
+     * @param player Player in question
+     * @return Whether the player has it
+     */
+    public abstract boolean hasRedeemable(Player player);
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
@@ -1,0 +1,82 @@
+package network.warzone.tgm.modules.ctf;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.modules.base.MatchBase;
+import network.warzone.tgm.modules.base.Redeemable;
+import network.warzone.tgm.modules.flag.FlagSubscriber;
+import network.warzone.tgm.modules.flag.MatchFlag;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.util.Parser;
+import network.warzone.tgm.util.Strings;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by yikes on 12/15/2019
+ */
+public class CTFModule extends MatchModule implements FlagSubscriber {
+    private CTFObjective objective;
+
+    private List<MatchBase> matchBases = new ArrayList<>();
+    private List<MatchFlag> matchFlags = new ArrayList<>();
+
+    @Override
+    public void load(Match match) {
+        JsonObject ctfJson = match.getMapContainer().getMapInfo().getJsonObject().get("ctf").getAsJsonObject();
+
+        // Deserialize flags json into MatchFlag instances
+        World world = match.getWorld();
+
+        for (JsonElement flagElem : ctfJson.get("flags").getAsJsonArray()) {
+            this.matchFlags.add(MatchFlag.deserialize(flagElem.getAsJsonObject(), this, world));
+        }
+
+        TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+        for (JsonElement element : ctfJson.get("bases").getAsJsonArray()) {
+            JsonObject baseObject = element.getAsJsonObject();
+            Location baseLocation = Parser.convertLocation(world, baseObject.get("location"));
+            MatchTeam matchTeam = teamManagerModule.getTeamById(baseObject.get("team").getAsString());
+            List<MatchFlag> flags = new ArrayList<>();
+            for (MatchFlag flag : matchFlags) {
+                if (flag.getTeam().equals(matchTeam)) continue;
+                flags.add(flag);
+            }
+            matchBases.add(new MatchBase(baseLocation, flags));
+        }
+
+        // CTF Objective
+        this.objective = CTFObjective.valueOf(Strings.getTechnicalName(ctfJson.get("objective").getAsString()));
+    }
+
+    @Override
+    public void pickup(MatchFlag flag, Player stealer) {
+
+    }
+
+    @Override
+    public void drop(MatchFlag flag, Player stealer, Player attacker) {
+
+    }
+
+    @Override
+    public void capture(MatchFlag flag, Player capturer) {
+
+    }
+
+    @Override
+    public void disable() {
+        for (MatchFlag matchFlag : matchFlags) matchFlag.unload();
+        for (MatchBase matchBase : matchBases) matchBase.unload();
+        matchFlags = null;
+        matchBases = null;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
@@ -5,17 +5,19 @@ import com.google.gson.JsonObject;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.modules.ItemRemoveModule;
 import network.warzone.tgm.modules.base.MatchBase;
-import network.warzone.tgm.modules.base.Redeemable;
-import network.warzone.tgm.modules.flag.FlagSubscriber;
+import network.warzone.tgm.modules.ctf.objective.*;
 import network.warzone.tgm.modules.flag.MatchFlag;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.modules.time.TimeLimitService;
+import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.util.Parser;
 import network.warzone.tgm.util.Strings;
+import network.warzone.tgm.util.itemstack.ItemUtils;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,60 +25,73 @@ import java.util.List;
 /**
  * Created by yikes on 12/15/2019
  */
-public class CTFModule extends MatchModule implements FlagSubscriber {
-    private CTFObjective objective;
-
+public class CTFModule extends MatchModule implements CTFControllerSubscriber {
+    private CTFController controller;
     private List<MatchBase> matchBases = new ArrayList<>();
     private List<MatchFlag> matchFlags = new ArrayList<>();
 
+    public static final String RIGHT_ARROW = "\u2192"; // →
+
     @Override
     public void load(Match match) {
+        // Grab CTF Json
         JsonObject ctfJson = match.getMapContainer().getMapInfo().getJsonObject().get("ctf").getAsJsonObject();
+
+        // Determine controller from objective
+        CTFObjective objective = CTFObjective.valueOf(Strings.getTechnicalName(ctfJson.get("objective").getAsString()));
+
+        // Based on Objective, determine controller and apply other effects
+        JsonObject optionObject = ctfJson.get("options").getAsJsonObject();
+        if (objective == CTFObjective.TIME) {
+            TimeModule timeModule = TGM.get().getModule(TimeModule.class);
+            int timeLimit = optionObject.get("time").getAsInt();
+            timeModule.setTimeLimit(timeLimit);
+            this.controller = new CTFTimeController(this, matchFlags,  timeLimit);
+            timeModule.setTimeLimitService((TimeLimitService) this.controller);
+        } else if (objective == CTFObjective.AMOUNT) {
+            int captureAmount = optionObject.get("captures").getAsInt();
+            this.controller = new CTFAmountController(this, matchFlags, captureAmount);
+        }
 
         // Deserialize flags json into MatchFlag instances
         World world = match.getWorld();
-
         for (JsonElement flagElem : ctfJson.get("flags").getAsJsonArray()) {
-            this.matchFlags.add(MatchFlag.deserialize(flagElem.getAsJsonObject(), this, world));
+            this.matchFlags.add(MatchFlag.deserialize(flagElem.getAsJsonObject(), controller, world));
         }
 
-        TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
-        for (JsonElement element : ctfJson.get("bases").getAsJsonArray()) {
-            JsonObject baseObject = element.getAsJsonObject();
-            Location baseLocation = Parser.convertLocation(world, baseObject.get("location"));
-            MatchTeam matchTeam = teamManagerModule.getTeamById(baseObject.get("team").getAsString());
-            List<MatchFlag> flags = new ArrayList<>();
-            for (MatchFlag flag : matchFlags) {
-                if (flag.getTeam().equals(matchTeam)) continue;
-                flags.add(flag);
+        // Don't allow flags to be dropped
+        ItemRemoveModule itemRemoveModule = TGM.get().getModule(ItemRemoveModule.class);
+        itemRemoveModule.addAll(ItemUtils.allBannerTypes());
+
+        // If Objective is amount, bases are required for flags to be captured
+        if (objective == CTFObjective.AMOUNT) {
+            TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+            for (JsonElement element : ctfJson.get("bases").getAsJsonArray()) {
+                JsonObject baseObject = element.getAsJsonObject();
+                Location baseLocation = Parser.convertLocation(world, baseObject.get("location"));
+                MatchTeam matchTeam = teamManagerModule.getTeamById(baseObject.get("team").getAsString());
+                List<MatchFlag> flags = new ArrayList<>();
+                for (MatchFlag flag : matchFlags) {
+                    if (flag.getTeam().equals(matchTeam)) continue;
+                    flags.add(flag);
+                }
+                matchBases.add(new MatchBase(baseLocation, flags));
             }
-            matchBases.add(new MatchBase(baseLocation, flags));
         }
-
-        // CTF Objective
-        this.objective = CTFObjective.valueOf(Strings.getTechnicalName(ctfJson.get("objective").getAsString()));
-    }
-
-    @Override
-    public void pickup(MatchFlag flag, Player stealer) {
-
-    }
-
-    @Override
-    public void drop(MatchFlag flag, Player stealer, Player attacker) {
-
-    }
-
-    @Override
-    public void capture(MatchFlag flag, Player capturer) {
-
     }
 
     @Override
     public void disable() {
         for (MatchFlag matchFlag : matchFlags) matchFlag.unload();
         for (MatchBase matchBase : matchBases) matchBase.unload();
+        controller.unload();
+        controller = null;
         matchFlags = null;
         matchBases = null;
+    }
+
+    @Override
+    public void gameOver(MatchTeam team) {
+        TGM.get().getMatchManager().endMatch(team);
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFObjective.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFObjective.java
@@ -1,0 +1,6 @@
+package network.warzone.tgm.modules.ctf;
+
+public enum CTFObjective {
+    TIME,
+    AMOUNT
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -3,9 +3,11 @@ package network.warzone.tgm.modules.ctf.objective;
 import network.warzone.tgm.modules.ctf.CTFModule;
 import network.warzone.tgm.modules.flag.MatchFlag;
 import network.warzone.tgm.modules.scoreboard.ScoreboardInitEvent;
+import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
 import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
 import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 
@@ -28,11 +30,13 @@ public class CTFAmountController extends CTFController {
     @Override
     public void pickup(MatchFlag flag, Player stealer) {
         super.pickup(flag, stealer);
+        updateAllScoreboards();
     }
 
     @Override
     public void drop(MatchFlag flag, Player stealer, Player attacker) {
         super.drop(flag, stealer, attacker);
+        updateAllScoreboards();
     }
 
     @Override
@@ -41,6 +45,8 @@ public class CTFAmountController extends CTFController {
         MatchTeam capturingTeam = teamManagerModule.getTeam(capturer);
         int currentScore = teamScores.getOrDefault(capturingTeam, 0);
         teamScores.put(capturingTeam, ++currentScore);
+
+        updateAllScoreboards();
         checkGameOver();
     }
 
@@ -53,29 +59,39 @@ public class CTFAmountController extends CTFController {
         updateScoreboard(event.getSimpleScoreboard());
     }
 
+    private void updateAllScoreboards() {
+        for (SimpleScoreboard scoreboard : scoreboardManagerModule.getScoreboards().values()) {
+            updateScoreboard(scoreboard);
+        }
+    }
+
     private void updateScoreboard(SimpleScoreboard scoreboard) {
-        int spaceCount = 0;
-        int positionOnScoreboard = 0;
+        scoreboard.removeAll(ScoreboardManagerModule.getReservedExclusions());
+        int spaceCount = 1;
+        int positionOnScoreboard = 1;
+        for (MatchTeam team : teamManagerModule.getTeams()) {
+            if (team.isSpectator()) continue;
+            scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+            scoreboard.add(getTeamPoints(team) + "/" + captureAmount + " captures", ++positionOnScoreboard);
+            scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
+        }
         scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        boolean addedAnyFlags = false;
         for (MatchFlag flag : allFlags) {
             if (flag.getFlagHolder() == null) continue;
+            if (!addedAnyFlags) addedAnyFlags = true;
             MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
             scoreboard.add(flag.getTeam().getColor() +
                     CTFModule.RIGHT_ARROW + " " + team.getColor() + flag.getFlagHolder().getName(), ++positionOnScoreboard);
         }
-        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-        for (MatchTeam team : teamManagerModule.getTeams()) {
-            if (team.isSpectator()) continue;
-            scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
-            scoreboard.add(getTeamPoints(team) + "/" + captureAmount, ++positionOnScoreboard);
-            scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-        }
+        if (addedAnyFlags) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        scoreboard.update();
     }
 
     private void checkGameOver() {
         MatchTeam teamWhoWon = null;
         for (Map.Entry<MatchTeam, Integer> entry : teamScores.entrySet()) {
-            if (!(entry.getValue() < captureAmount)) continue;
+            if (entry.getValue() < captureAmount) continue;
             teamWhoWon = entry.getKey();
             break;
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -1,0 +1,85 @@
+package network.warzone.tgm.modules.ctf.objective;
+
+import network.warzone.tgm.modules.ctf.CTFModule;
+import network.warzone.tgm.modules.flag.MatchFlag;
+import network.warzone.tgm.modules.scoreboard.ScoreboardInitEvent;
+import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
+import network.warzone.tgm.modules.team.MatchTeam;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by yikes on 12/15/2019
+ */
+public class CTFAmountController extends CTFController {
+    private Map<MatchTeam, Integer> teamScores = new HashMap<>();
+    private int captureAmount;
+
+    public CTFAmountController(CTFControllerSubscriber subscriber, List<MatchFlag> allFlags, int captureAmount) {
+        super(subscriber, allFlags);
+        this.captureAmount = captureAmount;
+    }
+
+    @Override
+    public void pickup(MatchFlag flag, Player stealer) {
+        super.pickup(flag, stealer);
+    }
+
+    @Override
+    public void drop(MatchFlag flag, Player stealer, Player attacker) {
+        super.drop(flag, stealer, attacker);
+    }
+
+    @Override
+    public void capture(MatchFlag flag, Player capturer) {
+        super.capture(flag, capturer);
+        MatchTeam capturingTeam = teamManagerModule.getTeam(capturer);
+        int currentScore = teamScores.getOrDefault(capturingTeam, 0);
+        teamScores.put(capturingTeam, ++currentScore);
+        checkGameOver();
+    }
+
+    private int getTeamPoints(MatchTeam team) {
+        return teamScores.getOrDefault(team, 0);
+    }
+
+    @EventHandler
+    public void onScoreboardInit(ScoreboardInitEvent event) {
+        updateScoreboard(event.getSimpleScoreboard());
+    }
+
+    private void updateScoreboard(SimpleScoreboard scoreboard) {
+        int spaceCount = 0;
+        int positionOnScoreboard = 0;
+        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        for (MatchFlag flag : allFlags) {
+            if (flag.getFlagHolder() == null) continue;
+            MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
+            scoreboard.add(flag.getTeam().getColor() +
+                    CTFModule.RIGHT_ARROW + " " + team.getColor() + flag.getFlagHolder().getName(), ++positionOnScoreboard);
+        }
+        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        for (MatchTeam team : teamManagerModule.getTeams()) {
+            if (team.isSpectator()) continue;
+            scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
+            scoreboard.add(getTeamPoints(team) + "/" + captureAmount, ++positionOnScoreboard);
+            scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        }
+    }
+
+    private void checkGameOver() {
+        MatchTeam teamWhoWon = null;
+        for (Map.Entry<MatchTeam, Integer> entry : teamScores.entrySet()) {
+            if (!(entry.getValue() < captureAmount)) continue;
+            teamWhoWon = entry.getKey();
+            break;
+        }
+        if (teamWhoWon == null) return;
+        super.gameOver(teamWhoWon);
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
@@ -58,6 +58,7 @@ public abstract class CTFController implements FlagSubscriber, Listener {
     @Override
     public void capture(MatchFlag flag, Player capturer) {
         capturer.getInventory().setHelmet(new ItemStack(Material.AIR));
+        capturer.removePotionEffect(PotionEffectType.SLOW);
         MatchTeam capturerTeam = teamManagerModule.getTeam(capturer);
         Bukkit.broadcastMessage(capturerTeam.getColor() + capturer.getName() + ChatColor.GRAY
                 + " captured " + flag.getTeam().getColor() + flag.getTeam().getAlias()

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
@@ -12,6 +12,8 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import java.util.List;
 
@@ -36,6 +38,7 @@ public abstract class CTFController implements FlagSubscriber, Listener {
     @Override
     public void pickup(MatchFlag flag, Player stealer) {
         stealer.getInventory().setHelmet(flag.generateBannerItem());
+        stealer.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 1000000, 2, true, false), true);
         MatchTeam team = teamManagerModule.getTeam(stealer);
         Bukkit.broadcastMessage(team.getColor() + stealer.getName() + ChatColor.GRAY
                 + " stole " + flag.getTeam().getColor() + flag.getTeam().getAlias()

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
@@ -45,6 +45,8 @@ public abstract class CTFController implements FlagSubscriber, Listener {
     @Override
     public void drop(MatchFlag flag, Player stealer, Player attacker) {
         MatchTeam team = teamManagerModule.getTeam(stealer);
+        if (team == null) team = teamManagerModule.getSpectators();
+        if (team == null) return;
         Bukkit.broadcastMessage(team.getColor() + stealer.getName() + ChatColor.GRAY
                 + " dropped " + flag.getTeam().getColor() + flag.getTeam().getAlias()
                 + ChatColor.GRAY + "'s flag");
@@ -53,7 +55,10 @@ public abstract class CTFController implements FlagSubscriber, Listener {
     @Override
     public void capture(MatchFlag flag, Player capturer) {
         capturer.getInventory().setHelmet(new ItemStack(Material.AIR));
-        Bukkit.broadcastMessage("gg a flag was captured by " + capturer.getName());
+        MatchTeam capturerTeam = teamManagerModule.getTeam(capturer);
+        Bukkit.broadcastMessage(capturerTeam.getColor() + capturer.getName() + ChatColor.GRAY
+                + " captured " + flag.getTeam().getColor() + flag.getTeam().getAlias()
+                + ChatColor.GRAY + "'s flag");
     }
 
     public void unload() {

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
@@ -1,0 +1,66 @@
+package network.warzone.tgm.modules.ctf.objective;
+
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.flag.FlagSubscriber;
+import network.warzone.tgm.modules.flag.MatchFlag;
+import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * Controls different objectives of CTF as a FlagSubscriber
+ * Also more than likely handles scoreboard
+ * Created by yikes on 12/15/2019
+ */
+public abstract class CTFController implements FlagSubscriber, Listener {
+    private CTFControllerSubscriber subscriber;
+    protected List<MatchFlag> allFlags;
+    protected TeamManagerModule teamManagerModule;
+    protected ScoreboardManagerModule scoreboardManagerModule;
+    public CTFController(CTFControllerSubscriber subscriber, List<MatchFlag> allFlags) {
+        this.subscriber = subscriber;
+        this.allFlags = allFlags;
+        this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+        this.scoreboardManagerModule = TGM.get().getModule(ScoreboardManagerModule.class);
+        TGM.registerEvents(this);
+    }
+
+    @Override
+    public void pickup(MatchFlag flag, Player stealer) {
+        stealer.getInventory().setHelmet(flag.generateBannerItem());
+        MatchTeam team = teamManagerModule.getTeam(stealer);
+        Bukkit.broadcastMessage(team.getColor() + stealer.getName() + ChatColor.GRAY
+                + " stole " + flag.getTeam().getColor() + flag.getTeam().getAlias()
+                + ChatColor.GRAY + "'s flag");
+    }
+
+    @Override
+    public void drop(MatchFlag flag, Player stealer, Player attacker) {
+        MatchTeam team = teamManagerModule.getTeam(stealer);
+        Bukkit.broadcastMessage(team.getColor() + stealer.getName() + ChatColor.GRAY
+                + " dropped " + flag.getTeam().getColor() + flag.getTeam().getAlias()
+                + ChatColor.GRAY + "'s flag");
+    }
+
+    @Override
+    public void capture(MatchFlag flag, Player capturer) {
+        capturer.getInventory().setHelmet(new ItemStack(Material.AIR));
+        Bukkit.broadcastMessage("gg a flag was captured by " + capturer.getName());
+    }
+
+    public void unload() {
+        TGM.unregisterEvents(this);
+    }
+
+    public final void gameOver(MatchTeam team) {
+        subscriber.gameOver(team);
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFControllerSubscriber.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFControllerSubscriber.java
@@ -1,0 +1,15 @@
+package network.warzone.tgm.modules.ctf.objective;
+
+import network.warzone.tgm.modules.team.MatchTeam;
+
+/**
+ * Represents a subscriber to a CTFController
+ * Created by yikes on 12/15/2019
+ */
+public interface CTFControllerSubscriber {
+    /**
+     * Called when controller says game is over
+     * @param team Team who won
+     */
+    void gameOver(MatchTeam team);
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFObjective.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFObjective.java
@@ -1,4 +1,4 @@
-package network.warzone.tgm.modules.ctf;
+package network.warzone.tgm.modules.ctf.objective;
 
 public enum CTFObjective {
     TIME,

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
@@ -1,0 +1,128 @@
+package network.warzone.tgm.modules.ctf.objective;
+
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.ctf.CTFModule;
+import network.warzone.tgm.modules.flag.MatchFlag;
+import network.warzone.tgm.modules.scoreboard.ScoreboardInitEvent;
+import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.time.TimeLimitService;
+import network.warzone.tgm.modules.time.TimeModule;
+import network.warzone.tgm.modules.time.TimeSubscriber;
+import network.warzone.tgm.util.Strings;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+
+import java.util.*;
+
+/**
+ * Created by yikes on 12/15/2019
+ */
+public class CTFTimeController extends CTFController implements TimeLimitService, TimeSubscriber {
+    private Map<MatchTeam, Integer> teamScores = new HashMap<>();
+    private Set<MatchTeam> currentFlagHolders = new HashSet<>();
+    private TimeModule timeModule;
+    private int timeLimit;
+    private int taskID;
+
+    public CTFTimeController(CTFControllerSubscriber subscriber, List<MatchFlag> allFlags, int timeLimit) {
+        super(subscriber, allFlags);
+        this.timeLimit = timeLimit;
+        this.timeModule = TGM.get().getModule(TimeModule.class);
+        timeModule.getTimeSubscribers().add(this);
+        taskID = Bukkit.getScheduler().scheduleSyncRepeatingTask(TGM.get(), () -> {
+            if (currentFlagHolders.size() == 0) return;
+            for (MatchTeam currentFlagHolder : currentFlagHolders) {
+                int currentScore = teamScores.getOrDefault(currentFlagHolder, 0);
+                teamScores.put(currentFlagHolder, ++currentScore);
+            }
+        }, 20L, 20L);
+    }
+
+    @Override
+    public void pickup(MatchFlag flag, Player stealer) {
+        super.pickup(flag, stealer);
+        currentFlagHolders.add(flag.getTeam());
+    }
+
+    @Override
+    public void drop(MatchFlag flag, Player stealer, Player attacker) {
+        super.drop(flag, stealer, attacker);
+        currentFlagHolders.remove(flag.getTeam());
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+        Bukkit.getScheduler().cancelTask(taskID);
+    }
+
+    @Override
+    public MatchTeam getWinnerTeam() {
+        int tieCount = 0;
+        MatchTeam winningTeam = null;
+        int mostPoints = -1;
+        for (Map.Entry<MatchTeam, Integer> teamEntry : teamScores.entrySet()) {
+            if (teamEntry.getValue() > mostPoints) {
+                tieCount = 0;
+                winningTeam = teamEntry.getKey();
+                mostPoints = teamEntry.getValue();
+            } else if (teamEntry.getValue() == mostPoints) {
+                tieCount++;
+            }
+        }
+        return (tieCount > 0) ? null : winningTeam;
+    }
+
+    private int getTeamPoints(MatchTeam team) {
+        return teamScores.getOrDefault(team, 0);
+    }
+
+    @EventHandler
+    public void onScoreboardInit(ScoreboardInitEvent event) {
+        updateScoreboard(event.getSimpleScoreboard());
+    }
+
+    private void updateScoreboard(SimpleScoreboard scoreboard) {
+        updateScoreboard(scoreboard, getFormattedTime());
+    }
+
+    private void updateScoreboard(SimpleScoreboard scoreboard, String formattedRemainingTime) {
+        int spaceCount = 0;
+        int positionOnScoreboard = 0;
+        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        for (MatchFlag flag : allFlags) {
+            if (flag.getFlagHolder() == null) continue;
+            MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
+            scoreboard.add(flag.getTeam().getColor() +
+                    CTFModule.RIGHT_ARROW + " " + team.getColor() + flag.getFlagHolder().getName(), ++positionOnScoreboard);
+        }
+        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        for (MatchTeam team : teamManagerModule.getTeams()) {
+            if (team.isSpectator()) continue;
+            scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
+            scoreboard.add(ChatColor.LIGHT_PURPLE.toString() + getTeamPoints(team) + " points", ++positionOnScoreboard);
+            scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        }
+        scoreboard.add("Time: " + ChatColor.GREEN + formattedRemainingTime, ++positionOnScoreboard);
+    }
+
+    @Override
+    public void processSecond(int elapsed) {
+        String remainingTime = getFormattedTime(elapsed);
+        for (SimpleScoreboard simpleScoreboard : scoreboardManagerModule.getScoreboards().values()) {
+            updateScoreboard(simpleScoreboard, remainingTime);
+        }
+    }
+
+    private String getFormattedTime() {
+        return getFormattedTime((int) timeModule.getTimeElapsed());
+    }
+
+    private String getFormattedTime(int elapsed) {
+        return Strings.formatTime(timeLimit - elapsed);
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/FlagSubscriber.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/FlagSubscriber.java
@@ -1,0 +1,10 @@
+package network.warzone.tgm.modules.flag;
+
+import org.bukkit.entity.Player;
+
+
+public interface FlagSubscriber {
+    void pickup(MatchFlag flag, Player stealer);
+    void drop(MatchFlag flag, Player stealer, Player attacker);
+    void capture(MatchFlag flag, Player capturer);
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -1,0 +1,162 @@
+package network.warzone.tgm.modules.flag;
+
+import com.google.gson.JsonObject;
+import lombok.Getter;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchStatus;
+import network.warzone.tgm.modules.base.PlayerRedeemable;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamChangeEvent;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.parser.banner.BannerPatternsDeserializer;
+import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
+import network.warzone.tgm.util.Parser;
+import network.warzone.tgm.util.Strings;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Banner;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Rotatable;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.List;
+
+@Getter
+public class MatchFlag extends PlayerRedeemable implements Listener {
+    // banner details
+    private List<Pattern> bannerPatterns;
+    private String bannerType;
+    private String rotation;
+    private Location location;
+
+    private FlagSubscriber flagSubscriber;
+    private MatchTeam team;
+    private Player flagHolder;
+
+    private Match match;
+    private TeamManagerModule teamManagerModule;
+
+    public MatchFlag(List<Pattern> bannerPatterns, String bannerType, String rotation, Location location, FlagSubscriber flagSubscriber, MatchTeam team) {
+
+        this.bannerPatterns = bannerPatterns;
+        this.bannerType = bannerType;
+        this.rotation = rotation;
+        this.location = location;
+        this.flagSubscriber = flagSubscriber;
+        this.team = team;
+
+        this.match = TGM.get().getMatchManager().getMatch();
+        this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+
+        TGM.registerEvents(this);
+        placeFlag();
+    }
+
+    private void refreshFlag() {
+        this.flagHolder = null;
+        placeFlag();
+    }
+
+    private void placeFlag() {
+        Block block = location.getBlock();
+        block.setType(Material.valueOf(Strings.getTechnicalName(bannerType) + "_BANNER"), false);
+
+        final BlockState state = block.getState();
+        if(state instanceof Banner) {
+            Banner banner = (Banner) block.getState();
+            banner.setPatterns(bannerPatterns);
+
+            BlockData bannerData = banner.getBlockData();
+            if (bannerData instanceof Rotatable) {
+                Rotatable bannerRotatable = (Rotatable) bannerData;
+                bannerRotatable.setRotation(BlockFace.valueOf(Strings.getTechnicalName(rotation)));
+                banner.setBlockData(bannerRotatable);
+            }
+
+            banner.update(true);
+        }
+    }
+
+    private boolean passesGeneralConditions(MatchTeam team) {
+        return match.getMatchStatus() == MatchStatus.MID && !team.isSpectator();
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (flagHolder != null) return;
+        MatchTeam playerTeam = teamManagerModule.getTeam(event.getPlayer());
+        if (!passesGeneralConditions(playerTeam) || playerTeam.equals(team)) return;
+        else if (event.getFrom().distanceSquared(location) > 1) return;
+
+        this.flagHolder = event.getPlayer();
+        location.getBlock().setType(Material.AIR);
+
+        flagSubscriber.pickup(this, event.getPlayer());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        if (match.getMatchStatus() != MatchStatus.MID || event.getPlayer() != flagHolder) return;
+        this.refreshFlag();
+        flagSubscriber.drop(this, event.getPlayer(), null);
+    }
+
+    @EventHandler
+    public void onTeamChange(TeamChangeEvent event) {
+        if (match.getMatchStatus() != MatchStatus.MID || event.getPlayerContext().getPlayer() != flagHolder || event.getTeam().equals(event.getOldTeam())) return;
+        this.refreshFlag();
+        flagSubscriber.drop(this, event.getPlayerContext().getPlayer(), null);
+    }
+
+    @EventHandler
+    public void onTGMDeath(TGMPlayerDeathEvent event) {
+        if (match.getMatchStatus() != MatchStatus.MID || event.getVictim() != flagHolder) return;
+        this.refreshFlag();
+        flagSubscriber.drop(this, event.getVictim(), event.getKiller());
+    }
+
+    public void unload() {
+        TGM.unregisterEvents(this);
+    }
+
+    @Override
+    public void redeem(Player player) {
+        this.refreshFlag();
+        flagSubscriber.capture(this, player);
+    }
+
+    @Override
+    public boolean hasRedeemable(Player player) {
+        return (flagHolder == player);
+    }
+
+    /**
+     * Returns a MatchFlag instance from JSON
+     * @param flagJson Flag JSON
+     * @param flagSubscriber Subscriber for event handling
+     * @param world World for location parsing
+     * @return Deserialized MatchFlag instance
+     */
+    public static MatchFlag deserialize(JsonObject flagJson, FlagSubscriber flagSubscriber, World world) {
+        List<Pattern> bannerPatterns = BannerPatternsDeserializer.parse(flagJson.get("patterns"));
+        String bannerType = flagJson.get("type").getAsString();
+        String bannerRotation = flagJson.has("rotation") ? flagJson.get("rotation").getAsString() : "EAST";
+        Location location = Parser.convertLocation(world, flagJson.get("location"));
+
+        TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+        MatchTeam team = teamManagerModule.getTeamById(flagJson.get("team").getAsString());
+
+        return new MatchFlag(bannerPatterns, bannerType, bannerRotation, location, flagSubscriber, team);
+    }
+
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -23,11 +23,15 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Rotatable;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BannerMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
 
@@ -62,6 +66,22 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         placeFlag();
     }
 
+    public Material generateMaterial() {
+        return Material.valueOf(Strings.getTechnicalName(bannerType) + "_BANNER");
+    }
+
+    public ItemStack generateBannerItem() {
+        ItemStack bannerItem = new ItemStack(generateMaterial());
+        ItemMeta itemMeta = bannerItem.getItemMeta();
+        if (itemMeta instanceof BannerMeta) {
+            BannerMeta bannerMeta = (BannerMeta) itemMeta;
+            bannerMeta.setPatterns(bannerPatterns);
+            bannerItem.setItemMeta(bannerMeta);
+        }
+        bannerItem.addEnchantment(Enchantment.BINDING_CURSE, 2);
+        return bannerItem;
+    }
+
     private void refreshFlag() {
         this.flagHolder = null;
         placeFlag();
@@ -69,7 +89,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
 
     private void placeFlag() {
         Block block = location.getBlock();
-        block.setType(Material.valueOf(Strings.getTechnicalName(bannerType) + "_BANNER"), false);
+        block.setType(generateMaterial(), false);
 
         final BlockState state = block.getState();
         if(state instanceof Banner) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/ScoreboardManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/ScoreboardManagerModule.java
@@ -20,6 +20,8 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scoreboard.Team;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -33,6 +35,14 @@ import java.util.UUID;
 public class ScoreboardManagerModule extends MatchModule implements Listener {
 
     private HashMap<UUID, SimpleScoreboard> scoreboards = new HashMap<>();
+    @Getter private static Set<Integer> reservedExclusions;
+
+    static {
+        reservedExclusions = new HashSet<>();
+        // Server IP lines
+        reservedExclusions.add(1);
+        reservedExclusions.add(0);
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onTeamChange(TeamChangeEvent event) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/SimpleScoreboard.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/SimpleScoreboard.java
@@ -49,6 +49,13 @@ public class SimpleScoreboard {
         scores.put(text, score);
     }
 
+    public void removeAll(Set<Integer> exclusions) {
+        for (Map.Entry<String, Integer> score : scores.entrySet()) {
+            if (exclusions.contains(score.getValue())) continue;
+            remove(score.getValue());
+        }
+    }
+
     public boolean remove(Integer score, String text) {
         return remove(score, text, true);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
@@ -59,4 +59,9 @@ public class MatchTeam {
         this.spawnPoints.add(spawnPoint);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof MatchTeam)) return false;
+        return ((MatchTeam) other).getId().equals(id);
+    }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/time/TimeModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/time/TimeModule.java
@@ -22,7 +22,7 @@ public class TimeModule extends MatchModule {
     private List<TimeSubscriber> timeSubscribers = new ArrayList<>();
 
     @Setter private boolean timeLimited = false;
-    @Setter private int timeLimit = 20*60; // Default
+    @Setter private int timeLimit = 20*60; // Default (20 minutes)
     private MatchTeam defaultWinner = null;
     //@Getter private List<TimeLimitService> services = new ArrayList<>();
     @Setter private TimeLimitService timeLimitService;
@@ -94,6 +94,9 @@ public class TimeModule extends MatchModule {
         broadcasts.clear();
     }
 
+    /**
+     * @return Time elapsed in seconds
+     */
     public double getTimeElapsed() {
         MatchStatus matchStatus = TGM.get().getMatchManager().getMatch().getMatchStatus();
         if (matchStatus == MatchStatus.MID) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/time/TimeSubscriber.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/time/TimeSubscriber.java
@@ -1,5 +1,9 @@
 package network.warzone.tgm.modules.time;
 
 public interface TimeSubscriber {
+    /**
+     * Called every second
+     * @param elapsed Time elapsed of match in seconds
+     */
     void processSecond(int elapsed);
 }

--- a/TGM/src/main/java/network/warzone/tgm/parser/banner/BannerPatternsDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/parser/banner/BannerPatternsDeserializer.java
@@ -1,0 +1,51 @@
+package network.warzone.tgm.parser.banner;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.*;
+import network.warzone.tgm.util.Strings;
+import org.bukkit.DyeColor;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.banner.PatternType;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Jorge on 11/08/2019
+ */
+public class BannerPatternsDeserializer implements JsonDeserializer<List<Pattern>> {
+
+    public static List<Pattern> parse(JsonElement jsonElement) {
+        Preconditions.checkArgument(jsonElement.isJsonArray(), "Banner patterns must be a JSON array");
+        List<Pattern> patterns = new ArrayList<>();
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        for (JsonElement element : jsonArray) {
+            if (element.isJsonPrimitive()) {
+                try {
+                    String in = element.getAsString();
+                    String[] args = in.split(":");
+                    DyeColor dyeColor = DyeColor.valueOf(Strings.getTechnicalName(args[0]));
+                    PatternType patternType = PatternType.valueOf(Strings.getTechnicalName(args[1]));
+                    if (patterns == null) patternType = PatternType.getByIdentifier(args[1]);
+                    patterns.add(new Pattern(dyeColor, patternType));
+                } catch (Exception ignored) {}
+            } else if (element.isJsonObject()) {
+                try {
+                    JsonObject jsonObject = element.getAsJsonObject();
+                    DyeColor dyeColor = DyeColor.valueOf(Strings.getTechnicalName(jsonObject.get("color").getAsString()));
+                    PatternType patternType = PatternType.valueOf(Strings.getTechnicalName(jsonObject.get("type").getAsString()));
+                    if (patterns == null) patternType = PatternType.getByIdentifier(jsonObject.get("type").getAsString());
+                    patterns.add(new Pattern(dyeColor, patternType));
+                } catch (Exception ignored) {}
+            }
+        }
+        return patterns;
+    }
+
+    @Override
+    public List<Pattern> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return parse(json);
+    }
+
+}

--- a/TGM/src/main/java/network/warzone/tgm/util/itemstack/ItemUtils.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/itemstack/ItemUtils.java
@@ -3,10 +3,22 @@ package network.warzone.tgm.util.itemstack;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Created by luke on 11/15/15.
  */
 public class ItemUtils {
+    private static Set<Material> bannerMaterials = new HashSet<>();
+
+    static {
+        for (Material material : Material.values()) {
+            if (material.name().contains("_BANNER") && !material.name().contains("LEGACY"))
+                bannerMaterials.add(material);
+        }
+    }
+
     public static boolean compare(ItemStack i1, ItemStack i2) {
         if (i1 != null && i2 != null) {
             if (i1.getItemMeta() != null && i2.getItemMeta() != null) {
@@ -41,5 +53,9 @@ public class ItemUtils {
             stringBuilder.append(word);
         }
         return stringBuilder.toString().trim();
+    }
+
+    public static Set<Material> allBannerTypes() {
+        return bannerMaterials;
     }
 }


### PR DESCRIPTION
- Adds Redeemables, objects that can be redeemed at bases.
- Bases are areas that check redeemable presences.
- New BannerPatternDeserializer for deserializing banner patterns (thanks to @jorgeberrex )
- Flags are redeemable and are not tied to the CTF gamemode

CTF Gamemode consists of two configurable objectives, amount and time. Amount is where a certain number of captures ends the game, time is where the team who has held the flag the longest in a time frame is the winner. Both objectives should support > 2 teams, although, only tested with 2 team maps.

Currently, when the flag is dropped it is returned back to the base. This can be improved on later to drop it at the location of the player.

JSON example
```json
{
  "gametype": "CTF",
  "ctf": {
    "bases": [
      {
        "team": "blue",
        "region": {
          "type": "cuboid",
          "min": "187, 4, -268",
          "max": "193, 10, -258"
        }
      },
      {
        "team": "red",
        "region": {
          "type": "cuboid",
          "min": "163, 4, -121",
          "max": "169, 10, -115"
        }
      }
    ],
    "flags": [
      {
        "team": "red",
        "location": "147, 7, -115",
        "type": "red",
        "rotation": "north",
        "patterns": [
          "red:cross"
        ]
      },
      {
        "team": "blue",
        "location": "209, 7, -268",
        "type": "blue",
        "rotation": "west",
        "patterns": [
          "blue:cross"
        ]
      }
    ],
    "objective": "amount",
    "options": {
      "captures": 5
    }
  }
}
```

For the time objective, you would modify the `objective` field and `options` object. `time` is in seconds.
```json
{
  "objective": "time",
  "options": {
    "time": 300
  }
}
```

Note the `amount` objective is strictly point based, it has respect to nothing else. If a map had multiple teams, and capture count was 2, intending that a team should capture each of the other's team flags, that would not be the case. A team could capture 2 of a single team's flag. It'd be best for something like that to exist as another objective (perhaps called `capture`), which again can be added later as this PR is already packed. I split the CTF logic into these objectives so that something like that could be implemented easily later on, also benefits the mapmaker in choosing what objective the map should be played.

Resolves #567 