### PR TITLE
Use literal 1.8 arrow knockback values

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/knockback/KnockbackModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/knockback/KnockbackModule.java
@@ -45,10 +45,6 @@ public class KnockbackModule extends MatchModule implements Listener {
         Vector arrowVelocity = a.getVelocity();
         float f3 = (float) Math.sqrt(arrowVelocity.getX() * arrowVelocity.getX() + arrowVelocity.getZ() * arrowVelocity.getZ());
         nmsHuman.h(arrowVelocity.getX() * (double) a.getKnockbackStrength() * 0.6000000238418579D / (double) f3, 0.1D, arrowVelocity.getZ() * (double) a.getKnockbackStrength() * 0.6000000238418579D / (double) f3);
-//        Vector normalVelocity = a.getVelocity();
-//        if (e.isOnGround()) normalVelocity.setY(0.3);
-//        else normalVelocity.setY(0);
-//        e.setVelocity(normalVelocity.normalize().multiply(0.2f));
     }
 
     private void applyMeleeKnockback(LivingEntity attacker, LivingEntity victim) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/knockback/KnockbackModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/knockback/KnockbackModule.java
@@ -1,6 +1,8 @@
 package network.warzone.tgm.modules.knockback;
 
+import net.minecraft.server.v1_15_R1.EntityPlayer;
 import network.warzone.tgm.match.MatchModule;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -39,10 +41,14 @@ public class KnockbackModule extends MatchModule implements Listener {
     }
 
     private void applyBowKnockback(Arrow a, Entity e) {
-        Vector normalVelocity = a.getVelocity();
-        if (e.isOnGround()) normalVelocity.setY(0.3);
-        else normalVelocity.setY(0);
-        e.setVelocity(normalVelocity.normalize().multiply(0.2f));
+        EntityPlayer nmsHuman = ((CraftPlayer) e).getHandle();
+        Vector arrowVelocity = a.getVelocity();
+        float f3 = (float) Math.sqrt(arrowVelocity.getX() * arrowVelocity.getX() + arrowVelocity.getZ() * arrowVelocity.getZ());
+        nmsHuman.h(arrowVelocity.getX() * (double) a.getKnockbackStrength() * 0.6000000238418579D / (double) f3, 0.1D, arrowVelocity.getZ() * (double) a.getKnockbackStrength() * 0.6000000238418579D / (double) f3);
+//        Vector normalVelocity = a.getVelocity();
+//        if (e.isOnGround()) normalVelocity.setY(0.3);
+//        else normalVelocity.setY(0);
+//        e.setVelocity(normalVelocity.normalize().multiply(0.2f));
     }
 
     private void applyMeleeKnockback(LivingEntity attacker, LivingEntity victim) {


### PR DESCRIPTION
Uses the motion values applied to an entity target when an entity is damaged by an arrow, from 1.8.8.

Should resolve #601 