### PR TITLE
Safe Disable Classes

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/classes/GameClassModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/classes/GameClassModule.java
@@ -229,6 +229,7 @@ public class GameClassModule extends MatchModule implements Listener {
 
     @SuppressWarnings("unchecked")
     public <T extends GameClass> T getGameClass(Class<T> clazz) {
+        if (gameClassSet == null) return null;
         for(GameClass gameClass : gameClassSet) {
             if (clazz.isInstance(gameClass)) return ((T) gameClass);
         }


### PR DESCRIPTION
Class set was assumed to be nonnull when the game disabled. Added null check.
Fixes #644 