### PR TITLE
Detailed ItemRemove scenarios

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/ItemRemoveModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ItemRemoveModule.java
@@ -1,6 +1,7 @@
 package network.warzone.tgm.modules;
 
 import com.google.gson.JsonElement;
+import lombok.Getter;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
@@ -20,26 +21,39 @@ import java.util.HashSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Removes item entities that match a material type on spawn.
  */
 public class ItemRemoveModule extends MatchModule implements Listener {
 
-    private final Set<Material> removed = new HashSet<>();
+    private final Set<ItemRemoveInfo> removed = new HashSet<>();
 
     private boolean removeAll = false;
 
+    public void add(ItemRemoveInfo info) {
+        this.removed.add(info);
+    }
+
     public void add(Material material) {
-        this.removed.add(material);
+        add(new ItemRemoveInfo(material));
     }
 
     public void addAll(Collection<Material> materials) {
-        removed.addAll(materials);
+        removed.addAll(materials.stream().map(ItemRemoveInfo::new).collect(Collectors.toSet()));
     }
 
     public void remove(Material material) {
-        this.removed.remove(material);
+        ItemRemoveInfo info = hasMaterial(material);
+        if (info != null) removed.remove(info);
+    }
+
+    public ItemRemoveInfo hasMaterial(Material material) {
+        for (ItemRemoveInfo info : removed) {
+            if (info.material == material) return info;
+        }
+        return null;
     }
 
     @Override
@@ -54,21 +68,21 @@ public class ItemRemoveModule extends MatchModule implements Listener {
                 try {
                     // 1.13 temp fix
                     if (Strings.getTechnicalName(itemElement.getAsString()).equalsIgnoreCase("WOOL")) {
-                        removed.add(Material.WHITE_WOOL);
-                        removed.add(Material.BLACK_WOOL);
-                        removed.add(Material.BLUE_WOOL);
-                        removed.add(Material.BROWN_WOOL);
-                        removed.add(Material.CYAN_WOOL);
-                        removed.add(Material.GRAY_WOOL);
-                        removed.add(Material.GREEN_WOOL);
-                        removed.add(Material.LIGHT_BLUE_WOOL);
-                        removed.add(Material.LIGHT_GRAY_WOOL);
-                        removed.add(Material.LIME_WOOL);
-                        removed.add(Material.MAGENTA_WOOL);
-                        removed.add(Material.ORANGE_WOOL);
+                        add(Material.WHITE_WOOL);
+                        add(Material.BLACK_WOOL);
+                        add(Material.BLUE_WOOL);
+                        add(Material.BROWN_WOOL);
+                        add(Material.CYAN_WOOL);
+                        add(Material.GRAY_WOOL);
+                        add(Material.GREEN_WOOL);
+                        add(Material.LIGHT_BLUE_WOOL);
+                        add(Material.LIGHT_GRAY_WOOL);
+                        add(Material.LIME_WOOL);
+                        add(Material.MAGENTA_WOOL);
+                        add(Material.ORANGE_WOOL);
                         return;
                     }
-                    removed.add(Material.valueOf(Strings.getTechnicalName(itemElement.getAsString())));
+                    add(Material.valueOf(Strings.getTechnicalName(itemElement.getAsString())));
                 } catch (Exception e) {
                     TGM.get().getPlayerManager().broadcastToAdmins(ChatColor.RED + "[JSON] Unknown material in itemremove module: \"" + itemElement.getAsString() + "\"");
                 }
@@ -89,7 +103,9 @@ public class ItemRemoveModule extends MatchModule implements Listener {
         }
         List<ItemStack> toRemove = new ArrayList<>();
         for (ItemStack itemStack : event.getDrops()) {
-            if (itemStack != null && removed.contains(itemStack.getType())) {
+            if (itemStack != null) {
+                ItemRemoveInfo info = hasMaterial(itemStack.getType());
+                if (info == null || !info.isPreventingDeathDrop()) continue;
                 toRemove.add(itemStack);
             }
         }
@@ -101,15 +117,48 @@ public class ItemRemoveModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onDrop(PlayerDropItemEvent event) {
-        if (removeAll || removed.contains(event.getItemDrop().getItemStack().getType())) {
+        if (removeAll) {
             event.getItemDrop().remove();
+            return;
         }
+        ItemRemoveInfo info = hasMaterial(event.getItemDrop().getItemStack().getType());
+        if (info != null && info.isPreventingPlayerDrop()) event.getItemDrop().remove();
     }
 
     @EventHandler
     public void onItemSpawn(ItemSpawnEvent event) {
-        if (removeAll || removed.contains(event.getEntity().getItemStack().getType())) {
+        if (removeAll) {
             event.setCancelled(true);
+            return;
+        }
+        ItemRemoveInfo info = hasMaterial(event.getEntity().getItemStack().getType());
+        if (info != null && info.isPreventingItemSpawn()) event.setCancelled(true);
+    }
+
+    @Getter
+    public static class ItemRemoveInfo {
+        private final Material material;
+        private boolean preventingDeathDrop = true;
+        private boolean preventingPlayerDrop = true;
+        private boolean preventingItemSpawn = true;
+
+        public ItemRemoveInfo(Material material) {
+            this.material = material;
+        }
+
+        public ItemRemoveInfo setPreventingDeathDrop(boolean preventingDeathDrop) {
+            this.preventingDeathDrop = preventingDeathDrop;
+            return this;
+        }
+
+        public ItemRemoveInfo setPreventingPlayerDrop(boolean preventingPlayerDrop) {
+            this.preventingPlayerDrop = preventingPlayerDrop;
+            return this;
+        }
+
+        public ItemRemoveInfo setPreventingItemSpawn(boolean preventingItemSpawn) {
+            this.preventingItemSpawn = preventingItemSpawn;
+            return this;
         }
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -134,7 +134,7 @@ public class CTWModule extends MatchModule implements Listener {
         //load wools
         for (WoolObjective woolObjective : this.wools) {
             woolObjective.load();
-            if (module != null) module.add(woolObjective.getBlock());
+            if (module != null) module.add(new ItemRemoveModule.ItemRemoveInfo(woolObjective.getBlock()).setPreventingItemSpawn(false));
         }
 
         if (this.wools.size() > 6) this.compactLayout = true;


### PR DESCRIPTION
These allow for materials to be specifically handled for a specific scenario, i.e. if an item should be able to spawn but not drop on death and not able to be dropped by a player. By default the wools added by CTWModule have it so wools are allowed to spawn but the other scenarios are prevented. Should fix #645 