### PR TITLE
Add /nicks reset

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -35,6 +35,11 @@ public class NickCommands {
         }
 
         if (cmd.argsLength() == 1 && cmd.getString(0).equals("reset")) {
+            if (!sender.hasPermission("tgm.command.nicks.reset")) {
+                sender.sendMessage(ChatColor.RED + "Insufficient permissions.");
+                return;
+            }
+
             List<UUID> nickedPlayers = new ArrayList<>();
 
             originalNames.forEach((uuid, originalName) -> nickedPlayers.add(uuid));

--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -17,12 +17,13 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class NickCommands {
 
-    @Command(aliases = {"nicks"}, desc = "View all nicked players")
+    @Command(aliases = {"nicks"}, desc = "View all nicked players", max = 1)
     @CommandPermissions({"tgm.command.whois"})
     public static void nicks(CommandContext cmd, CommandSender sender) {
         HashMap<UUID, String> originalNames = TGM.get().getNickManager().getOriginalNames();
@@ -30,6 +31,26 @@ public class NickCommands {
 
         if (originalNames.size() == 0) {
             sender.sendMessage(ChatColor.RED + "No nicked players found.");
+            return;
+        }
+
+        if (cmd.argsLength() == 1 && cmd.getString(0).equals("reset")) {
+            List<UUID> nickedPlayers = new ArrayList<>();
+
+            originalNames.forEach((uuid, originalName) -> nickedPlayers.add(uuid));
+
+            for (UUID nickedPlayer : nickedPlayers) {
+                Player player = Bukkit.getPlayer(nickedPlayer);
+                if (player != null) {
+                    try {
+                        TGM.get().getNickManager().reset(player, true);
+                        sender.sendMessage(ChatColor.GREEN + "Unnicked: " + ChatColor.DARK_PURPLE + player.getName());
+                    } catch (NoSuchFieldException | IllegalAccessException e) {
+                        sender.sendMessage(ChatColor.RED + "Failed to unnick: " + ChatColor.DARK_PURPLE + player.getName());
+                    }
+                }
+            }
+
             return;
         }
 

--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -122,7 +122,7 @@ public class JoinManager implements Listener {
                 player.sendMessage(ChatColor.RED + "Your name must be reset because the player has joined!");
                 try {
                     nickManager.reset(player, false);
-                } catch (NoSuchFieldException | IllegalAccessException | UnirestException e) {
+                } catch (NoSuchFieldException | IllegalAccessException e) {
                     p.sendMessage(ChatConstant.ERROR_RATE_LIMITED.toString());
                 }
             }
@@ -159,7 +159,7 @@ public class JoinManager implements Listener {
                 p.sendMessage(ChatColor.RED + "Could not apply the queued nick. The player is already online!");
                 try {
                     nickManager.reset(p, false);
-                } catch (NoSuchFieldException | IllegalAccessException | UnirestException e) {
+                } catch (NoSuchFieldException | IllegalAccessException e) {
                     p.sendMessage(ChatConstant.ERROR_RATE_LIMITED.toString());
                 }
                 // Invalidate the nick.

--- a/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
@@ -80,7 +80,7 @@ public class NickManager {
         setSkin(player, newName, null);
     }
 
-    public void reset(Player player, boolean kick) throws NoSuchFieldException, IllegalAccessException, UnirestException {
+    public void reset(Player player, boolean kick) throws NoSuchFieldException, IllegalAccessException {
         if (kick) {
             originalNames.remove(player.getUniqueId());
             nickNames.remove(player.getUniqueId());


### PR DESCRIPTION
It kicks all the players to unnick them, but it's still better than no /nicks reset at all, right?

This commit also removes an obsolete UnirestException which is never thrown.

https://github.com/Warzone/TGM/issues/618