### PR TITLE
/alts enhancement

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -248,6 +248,7 @@ public class PunishCommands {
         });
     }
 
+    @SuppressWarnings("DuplicatedCode")
     @Command(aliases = "alts", desc = "Lookup alts of a user", min = 1, max = 1, usage = "(name)")
     @CommandPermissions("tgm.lookup")
     public static void alts(CommandContext cmd, CommandSender sender) {
@@ -262,12 +263,44 @@ public class PunishCommands {
                     sender.sendMessage(ChatColor.GREEN + response.getLookupUser().getName() + " has no known alts.");
                     return;
                 }
+
                 String name = response.getLookupUser().getName();
                 List<String> alts = new ArrayList<>(Arrays.asList(
                         "",
                         ChatColor.AQUA + name + (name.endsWith("s") ? "'" : "'s") + " known alts:"
                 ));
-                alts.addAll(response.getUsers().stream().map(user -> ChatColor.GRAY + " - " + ChatColor.WHITE + user.getName()).collect(Collectors.toList()));
+
+                for (UserProfile user : response.getUsers()) {
+                    boolean isBanned = false;
+                    boolean isMuted = false;
+
+                    PunishmentsListResponse punishmentsListResponse = TGM.get().getTeamClient().getPunishments(new PunishmentsListRequest(user.getName(), null));
+                    if (!punishmentsListResponse.isNotFound()) {
+                        for (Punishment punishment : punishmentsListResponse.getPunishments()) {
+                            if (punishment.getType().toUpperCase().equals("BAN") && punishment.isActive()) {
+                                isBanned = true;
+                                break;
+                            }
+
+                            if (punishment.getType().toUpperCase().equals("MUTE") && punishment.isActive()) {
+                                isMuted = true;
+                            }
+                        }
+                    }
+
+                    ChatColor chatColor = ChatColor.WHITE;
+
+                    if (isMuted) {
+                        chatColor = ChatColor.YELLOW;
+                    }
+
+                    if (isBanned) {
+                        chatColor = ChatColor.RED;
+                    }
+
+                    alts.add(ChatColor.GRAY + " - " + chatColor + user.getName());
+                }
+
                 alts.add(" ");
                 sender.sendMessage(alts.toArray(new String[0]));
             }


### PR DESCRIPTION
This adds the first feature mentioned in https://github.com/Warzone/TGM/issues/589

It gets the punishments for each alt and:
- Leaves the name white if no active mute/ban is found
- Makes the name yellow if only an active mute has been found
- Makes the name red if an active ban has been found.

Active bans override active mutes.

I'm not 100% sure if this is the most efficient way to add this feature, so it would be nice if someone with more knowledge could check the code.


Here are some screenshots:
![image](https://user-images.githubusercontent.com/7355350/79970352-14aa8580-8493-11ea-9809-cc93cb400138.png)
![image](https://user-images.githubusercontent.com/7355350/79970412-29871900-8493-11ea-8119-e982a7278599.png)
![image](https://user-images.githubusercontent.com/7355350/79970436-31df5400-8493-11ea-9f93-9cf671997187.png)