### PR TITLE
Return on 'Unknown time' error

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -195,6 +195,7 @@ public class CycleCommands {
                     time = cmd.getInteger(0);
                 } catch (CommandNumberFormatException e) {
                     sender.sendMessage(ChatColor.RED + "Unknown time \"" + cmd.getString(0) + "\"");
+                    return;
                 }
             }
             sender.sendMessage(ChatColor.GREEN + "Cycling in " + time + " seconds.");
@@ -215,6 +216,7 @@ public class CycleCommands {
                     time = cmd.getInteger(0);
                 } catch (CommandNumberFormatException e) {
                     sender.sendMessage(ChatColor.RED + "Unknown time \"" + cmd.getString(0) + "\"");
+                    return;
                 }
             }
             boolean soloStart = Bukkit.getOnlinePlayers().size() <= 1;


### PR DESCRIPTION
This PR will stop the command execution if the 'Unknown time' error is thrown.

Before this, using the incorrect time format in the `/start` and `/cycle` commands would cause it to say "Unknown time ..." but still execute the command, now the command execution will stop if the time is unknown.

I tested these changes and they work fine.