### PR TITLE
change match references

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManager.java
@@ -115,6 +115,7 @@ public class MatchManager {
 
         //if a match is currently running, unload it.
         if (oldMatch != null) {
+            File worldFolder = oldMatch.getWorld().getWorldFolder();
             oldMatch.getWorld().getPlayers().forEach(player ->
                     player.teleport(world.getSpawnLocation()));
 
@@ -125,7 +126,7 @@ public class MatchManager {
             if (!save)
                 Bukkit.getScheduler().runTaskLaterAsynchronously(TGM.get(), () -> {
                     try {
-                        FileUtils.deleteDirectory(oldMatch.getWorld().getWorldFolder());
+                        FileUtils.deleteDirectory(worldFolder);
                     } catch (IOException e) {
                         e.printStackTrace();
                     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/MapCommandsModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MapCommandsModule.java
@@ -11,7 +11,6 @@ import java.util.List;
 // TODO: Make a better event actions module
 public class MapCommandsModule extends MatchModule {
 
-    private Match match;
     private List<String> startCommands = new ArrayList<>();
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MatchResultModule.java
@@ -11,6 +11,9 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.player.event.PlayerJoinTeamAttemptEvent;
 import network.warzone.tgm.player.event.TGMPlayerRespawnEvent;
+
+import java.lang.ref.WeakReference;
+
 import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,12 +24,12 @@ import org.bukkit.potion.PotionEffectType;
 
 public class MatchResultModule extends MatchModule implements Listener {
 
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManagerModule;
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
     }
 
@@ -101,7 +104,7 @@ public class MatchResultModule extends MatchModule implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onMatchResult(PlayerJoinTeamAttemptEvent event) {
-        if (match.getMatchStatus().equals(MatchStatus.POST)) {
+        if (match.get().getMatchStatus().equals(MatchStatus.POST)) {
             event.getPlayerContext().getPlayer().sendMessage(ChatColor.RED + "The match has already ended.");
             event.setCancelled(true);
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
@@ -16,6 +16,9 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.player.event.TGMPlayerRespawnEvent;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.Players;
+
+import java.lang.ref.WeakReference;
+
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.event.EventHandler;
@@ -24,14 +27,14 @@ import org.bukkit.util.Vector;
 
 @Getter
 public class SpawnPointHandlerModule extends MatchModule implements Listener {
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManagerModule;
     private SpectatorModule spectatorModule;
     private GameClassModule gameClassModule;
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.teamManagerModule = match.getModule(TeamManagerModule.class);
         this.spectatorModule = match.getModule(SpectatorModule.class);
         gameClassModule = TGM.get().getModule(GameClassModule.class);
@@ -62,7 +65,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
     }
 
     public void spawnPlayer(PlayerContext playerContext, MatchTeam matchTeam, boolean teleport, boolean firstSpawn) {
-        boolean reset = firstSpawn || !match.getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY);
+        boolean reset = firstSpawn || !match.get().getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY);
         Players.reset(playerContext.getPlayer(), true, !reset);
 
         if (teleport) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -37,12 +37,13 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 
 @ModuleData(load = ModuleLoadTime.EARLIER) @Getter
 public class SpectatorModule extends MatchModule implements Listener {
 
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManagerModule;
 
     private MatchTeam spectators;
@@ -75,7 +76,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.teamManagerModule = match.getModule(TeamManagerModule.class);
         this.respawnModule = match.getModule(RespawnModule.class);
         this.spectators = teamManagerModule.getSpectators();
@@ -306,7 +307,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        if (match.getMatchStatus() == MatchStatus.PRE || teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
+        if (match.get().getMatchStatus() == MatchStatus.PRE || teamManagerModule.getTeam(event.getPlayer()).isSpectator()) {
             event.setCancelled(true);
             if (event.getItem() == null) return;
             if (event.getItem().isSimilar(teamSelectionItem)) {
@@ -437,7 +438,7 @@ public class SpectatorModule extends MatchModule implements Listener {
     }
 
     public void printObjective(Player player) {
-        MapInfo mapInfo = this.match.getMapContainer().getMapInfo();
+        MapInfo mapInfo = this.match.get().getMapContainer().getMapInfo();
         String objective;
         if (mapInfo.getObjective() != null) {
             objective = mapInfo.getObjective();

--- a/TGM/src/main/java/network/warzone/tgm/modules/StatsModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/StatsModule.java
@@ -22,9 +22,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
  */
 @Getter
 public class StatsModule extends MatchModule implements Listener{
-
-    private Match match;
-
     private int xpBarTaskId;
 
     private boolean statsDisabled = false;
@@ -33,7 +30,6 @@ public class StatsModule extends MatchModule implements Listener{
 
     @Override
     public void load(Match match) {
-        this.match = match;
 
         if (match.getMapContainer().getMapInfo().getJsonObject().has("stats")) {
             JsonObject statsObj = (JsonObject) match.getMapContainer().getMapInfo().getJsonObject().get("stats");
@@ -61,7 +57,6 @@ public class StatsModule extends MatchModule implements Listener{
 
     @Override
     public void unload() {
-        this.match = null;
         if (isShowLevel()) Bukkit.getScheduler().cancelTask(xpBarTaskId);
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -29,6 +29,7 @@ import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -50,13 +51,13 @@ public class BlitzModule extends MatchModule implements Listener {
     private String subtitle = ChatColor.GREEN + "Remaining lives:  " + ChatColor.YELLOW + "%lives%";
     private String actionbar = "";
 
-    private Match match;
+    private WeakReference<Match> match;
 
     private final RespawnRule respawnRule = new RespawnRule(null, 3000, false, false, false);
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
         JsonObject mapInfo = match.getMapContainer().getMapInfo().getJsonObject();
 
@@ -143,7 +144,7 @@ public class BlitzModule extends MatchModule implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onJoinAttempt(PlayerJoinTeamAttemptEvent event) {
-        if (!this.match.getMatchStatus().equals(MatchStatus.PRE)) {
+        if (!this.match.get().getMatchStatus().equals(MatchStatus.PRE)) {
             event.getPlayerContext().getPlayer().sendMessage(ChatColor.RED + "You can't pick a team after the match starts in this mode.");
             event.setCancelled(true);
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/countdown/CountdownManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/countdown/CountdownManagerModule.java
@@ -15,6 +15,7 @@ import network.warzone.tgm.util.Strings;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ import java.util.Map;
 @ModuleData(load = ModuleLoadTime.EARLIEST)
 public class CountdownManagerModule extends MatchModule {
 
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManagerModule;
     private TaskedModuleManager taskedModuleManager;
 
@@ -34,7 +35,7 @@ public class CountdownManagerModule extends MatchModule {
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.teamManagerModule = match.getModule(TeamManagerModule.class);
         this.taskedModuleManager = match.getModule(TaskedModuleManager.class);
         match.getModules().add(new StartCountdown());
@@ -89,7 +90,7 @@ public class CountdownManagerModule extends MatchModule {
     public void addCountdown(String id, CustomCountdown countdown) {
         this.customCountdowns.put(id, countdown);
         TGM.registerEvents(countdown);
-        this.match.getModules().add(countdown);
+        this.match.get().getModules().add(countdown);
         this.taskedModuleManager.addTaskedModule(countdown);
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/death/DeathModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/death/DeathModule.java
@@ -21,6 +21,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Objects;
@@ -30,14 +31,14 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class DeathModule extends MatchModule implements Listener {
 
-    private Match match;
+    private WeakReference<Match> match;
 
     private HashMap<UUID, DeathInfo> players = new HashMap<>();
     private HashMap<UUID, Boolean> dead = new HashMap<>();
     private TeamManagerModule teamManagerModule;
 
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         teamManagerModule = match.getModule(TeamManagerModule.class);
     }
 
@@ -58,7 +59,7 @@ public class DeathModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onEntityDamage(EntityDamageEvent event) {
-        if (this.match.getMatchStatus() == MatchStatus.POST) {
+        if (this.match.get().getMatchStatus() == MatchStatus.POST) {
             event.setCancelled(true);
             return;
         }
@@ -139,7 +140,7 @@ public class DeathModule extends MatchModule implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onPlayerDeath(TGMPlayerDeathEvent event) {
-        if (match.getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY)) return;
+        if (match.get().getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY)) return;
         for (ItemStack stack : event.getDrops()) {
             if (stack != null) {
                 event.getVictim().getWorld().dropItemNaturally(event.getDeathLocation(), stack);

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -12,6 +12,7 @@ import network.warzone.tgm.modules.filter.type.*;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,19 +20,19 @@ public class FilterManagerModule extends MatchModule {
 
     private List<FilterType> filterTypes = new ArrayList<>();
     
-    private Match match;
+    private WeakReference<Match> match;
     
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
     }
 
     @Override
     public void enable() {
-        if (match.getMapContainer().getMapInfo().getJsonObject().has("filters")) {
-            for (JsonElement filterElement : match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("filters")) {
+        if (match.get().getMapContainer().getMapInfo().getJsonObject().has("filters")) {
+            for (JsonElement filterElement : match.get().getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("filters")) {
                 JsonObject filterJson = filterElement.getAsJsonObject();
-                for (FilterType filterType : initFilter(match, filterJson)) {
+                for (FilterType filterType : initFilter(match.get(), filterJson)) {
                     filterTypes.add(filterType);
                     if (filterType instanceof Listener) {
                         TGM.registerEvents((Listener) filterType);

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -40,6 +40,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 @Getter
@@ -56,7 +57,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
 
     private Region protectiveRegion;
 
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManagerModule;
     private RespawnModule respawnModule;
 
@@ -69,7 +70,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         this.flagSubscriber = flagSubscriber;
         this.team = team;
 
-        this.match = TGM.get().getMatchManager().getMatch();
+        this.match = new WeakReference<Match>(TGM.get().getMatchManager().getMatch());
         this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
         this.respawnModule = TGM.get().getModule(RespawnModule.class);
 
@@ -147,7 +148,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
     }
 
     private boolean passesGeneralConditions(MatchTeam team) {
-        return match.getMatchStatus() == MatchStatus.MID && !team.isSpectator();
+        return match.get().getMatchStatus() == MatchStatus.MID && !team.isSpectator();
     }
 
     @EventHandler
@@ -167,21 +168,21 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
-        if (match.getMatchStatus() != MatchStatus.MID || event.getPlayer() != flagHolder) return;
+        if (match.get().getMatchStatus() != MatchStatus.MID || event.getPlayer() != flagHolder) return;
         this.refreshFlag();
         flagSubscriber.drop(this, event.getPlayer(), null);
     }
 
     @EventHandler
     public void onTeamChange(TeamChangeEvent event) {
-        if (match.getMatchStatus() != MatchStatus.MID || event.getPlayerContext().getPlayer() != flagHolder || event.getTeam().equals(event.getOldTeam())) return;
+        if (match.get().getMatchStatus() != MatchStatus.MID || event.getPlayerContext().getPlayer() != flagHolder || event.getTeam().equals(event.getOldTeam())) return;
         this.refreshFlag();
         flagSubscriber.drop(this, event.getPlayerContext().getPlayer(), null);
     }
 
     @EventHandler
     public void onTGMDeath(TGMPlayerDeathEvent event) {
-        if (match.getMatchStatus() != MatchStatus.MID || event.getVictim() != flagHolder) return;
+        if (match.get().getMatchStatus() != MatchStatus.MID || event.getVictim() != flagHolder) return;
         this.refreshFlag();
         flagSubscriber.drop(this, event.getVictim(), event.getKiller());
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -38,6 +38,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,7 +50,7 @@ import java.util.Random;
 @Getter
 public class InfectionModule extends MatchModule implements Listener, TimeSubscriber {
 
-    private Match match;
+    private WeakReference<Match> match;
     private TeamManagerModule teamManager;
     private HashMap<Integer, String> teamScoreboardLines = new HashMap<>();
     private HashMap<String, Integer> teamAliveScoreboardLines = new HashMap<>();
@@ -73,7 +74,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
         length = json.get("length").getAsInt();
         teamManager = match.getModule(TeamManagerModule.class);
         deathModule = match.getModule(DeathModule.class);
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         this.humans = teamManager.getTeamById("humans");
         this.infected = teamManager.getTeamById("infected");
         TimeModule time = TGM.get().getModule(TimeModule.class);
@@ -178,7 +179,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
 
     @EventHandler(ignoreCancelled = true)
     public void onJoinAttempt(PlayerJoinTeamAttemptEvent event) {
-        if (this.match.getMatchStatus().equals(MatchStatus.PRE)) {
+        if (this.match.get().getMatchStatus().equals(MatchStatus.PRE)) {
             if (event.isAutoJoin()) {
                 event.setTeam(this.humans);
             }
@@ -249,7 +250,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
         if (defaultScoreboardLoaded) {
             for (SimpleScoreboard simpleScoreboard : scoreboardManagerController.getScoreboards().values()) refreshOnlyDynamicScoreboard(simpleScoreboard);
         }
-        if (teamManager.getTeamById("humans").getMembers().size() == 0 && match.getMatchStatus().equals(MatchStatus.MID)) {
+        if (teamManager.getTeamById("humans").getMembers().size() == 0 && match.get().getMatchStatus().equals(MatchStatus.MID)) {
             TGM.get().getMatchManager().endMatch(teamManager.getTeamById("infected"));
         }
         event.getPlayerContext().getPlayer().setGameMode(GameMode.ADVENTURE);
@@ -272,7 +273,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
     }
 
     private void handleQuit(PlayerEvent event) {
-        if (teamManager.getTeamById("infected").getMembers().size() == 0 && match.getMatchStatus().equals(MatchStatus.MID)) {
+        if (teamManager.getTeamById("infected").getMembers().size() == 0 && match.get().getMatchStatus().equals(MatchStatus.MID)) {
             PlayerContext player = teamManager.getTeamById("humans").getMembers().get(teamManager.getTeamById("humans").getMembers().size() - 1);
             broadcastMessage(String.format("&2&l%s &7has been infected!", player.getPlayer().getName()));
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakModule.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 
 /**
@@ -23,7 +24,7 @@ import java.util.*;
 @Getter
 public class KillstreakModule extends MatchModule implements Listener {
 
-    private Match match;
+    private WeakReference<Match> match;
 
     private DeathModule deathModule;
 
@@ -32,7 +33,7 @@ public class KillstreakModule extends MatchModule implements Listener {
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         deathModule = match.getModule(DeathModule.class);
         this.addDefaults();
         if (match.getMapContainer().getMapInfo().getJsonObject().has("killstreaks")) {
@@ -134,7 +135,7 @@ public class KillstreakModule extends MatchModule implements Listener {
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &6&l%count%&r&7!")
                         .setActions(Arrays.asList(
                                 new SoundKillstreakAction(Sound.ENTITY_WITHER_AMBIENT, SoundKillstreakAction.SoundTarget.EVERYONE, 7.0F, 1.0F),
-                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.CREEPER).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
+                                new FireworkKillstreakAction(new Location(match.get().getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.CREEPER).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
@@ -142,7 +143,7 @@ public class KillstreakModule extends MatchModule implements Listener {
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &c&l%count%&r&7!")
                         .setActions(Arrays.asList(
                                 new SoundKillstreakAction(Sound.ENTITY_ENDER_DRAGON_GROWL, SoundKillstreakAction.SoundTarget.EVERYONE, 1000.0F, 1.0F),
-                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
+                                new FireworkKillstreakAction(new Location(match.get().getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
@@ -150,7 +151,7 @@ public class KillstreakModule extends MatchModule implements Listener {
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &3&l%count%&r&7!")
                         .setActions(Arrays.asList(
                                 new SoundKillstreakAction(Sound.ENTITY_WITHER_SPAWN, SoundKillstreakAction.SoundTarget.EVERYONE, 1000.0F, 1.4F),
-                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL_LARGE).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
+                                new FireworkKillstreakAction(new Location(match.get().getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL_LARGE).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
@@ -158,7 +159,7 @@ public class KillstreakModule extends MatchModule implements Listener {
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &5&l%count%&r&7!")
                         .setActions(Arrays.asList(
                                 new SoundKillstreakAction(Sound.UI_TOAST_CHALLENGE_COMPLETE, SoundKillstreakAction.SoundTarget.PLAYER, 1000.0F, 1.0F),
-                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.STAR).withColor(Color.fromRGB(16766776)).withFade(Color.fromRGB(16774912)).build(), 0)
+                                new FireworkKillstreakAction(new Location(match.get().getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.STAR).withColor(Color.fromRGB(16766776)).withFade(Color.fromRGB(16774912)).build(), 0)
                         ))
         ));
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/screens/ScreenManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/screens/ScreenManagerModule.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.Map;
  */
 public class ScreenManagerModule extends MatchModule {
 
-    private Match match;
+    private WeakReference<Match> match;
 
     private Map<String, Screen> screens = new HashMap<>();
 
@@ -26,7 +27,7 @@ public class ScreenManagerModule extends MatchModule {
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         JsonObject jsonObject = match.getMapContainer().getMapInfo().getJsonObject();
         if (jsonObject.has("screens")) {
             for (JsonElement jsonElement : jsonObject.getAsJsonArray("screens")) {
@@ -56,7 +57,7 @@ public class ScreenManagerModule extends MatchModule {
                     buttons.add(Button.deserialize(buttonElement.getAsJsonObject()));
                 }
             }
-            Screen screen = new Screen(this.match, title, size, buttons);
+            Screen screen = new Screen(this.match.get(), title, size, buttons);
             if (jsonObject.has("id")) {
                 this.screens.put(jsonObject.get("id").getAsString(), screen);
             }

--- a/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ import java.util.Map;
 @Getter
 public class TDMModule extends MatchModule implements Listener {
     
-    private Match match;
+    private WeakReference<Match> match;
     private PointsModule pointsModule;
     private TeamManagerModule teamManager;
     private TDMObjective tdmObjective = TDMObjective.KILLS;
@@ -37,7 +38,7 @@ public class TDMModule extends MatchModule implements Listener {
 
     @Override
     public void load(Match match) {
-        this.match = match;
+        this.match = new WeakReference<Match>(match);
         teamManager = TGM.get().getModule(TeamManagerModule.class);
 
         if (match.getMapContainer().getMapInfo().getJsonObject().has("tdm")) {


### PR DESCRIPTION
change some module match references to weak references to prevent match objects from not being garbage collected.
note: these are not all the references.

![somerefs](https://i.imgur.com/uDF7tf3.png)

as a result after multiple matches you can observe ~3 match instances in a heap dump, after this PR there is only 1 reference to the current match as there should be. havent tested if this functionally messes with anything, though it should not as the weak references should always resolve because of the active matchmanager reference