### PR TITLE
Alts enhancements #2

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -288,6 +288,10 @@ public class PunishCommands {
 
                     ChatColor chatColor = ChatColor.WHITE;
 
+                    if (Bukkit.getPlayer(user.getName()) != null) {
+                        chatColor = ChatColor.GREEN;
+                    }
+
                     if (isMuted) {
                         chatColor = ChatColor.YELLOW;
                     }

--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -3,6 +3,10 @@ package network.warzone.tgm.join;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.MatchPostLoadEvent;
 import network.warzone.tgm.modules.chat.ChatConstant;
@@ -12,10 +16,7 @@ import network.warzone.tgm.nickname.QueuedNick;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.HashMaps;
 import network.warzone.tgm.util.Ranks;
-import network.warzone.warzoneapi.models.PlayerLogin;
-import network.warzone.warzoneapi.models.Punishment;
-import network.warzone.warzoneapi.models.Skin;
-import network.warzone.warzoneapi.models.UserProfile;
+import network.warzone.warzoneapi.models.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -186,6 +187,61 @@ public class JoinManager implements Listener {
 
         if (playerContext.getUserProfile().isNew()) joinMsg += ChatColor.LIGHT_PURPLE + " [NEW]";
         event.setJoinMessage(joinMsg);
+
+        Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> { // Check alts asynchronously to prevent delaying the join event
+            PlayerAltsResponse response = TGM.get().getTeamClient().getAlts(event.getPlayer().getName());
+            if (response != null && !response.isError() && !response.getUsers().isEmpty()) {
+                List<String> punishedAlts = new ArrayList<>();
+
+                boolean banned = false;
+
+                for (UserProfile user : response.getUsers()) {
+                    PunishmentsListResponse punishmentsListResponse = TGM.get().getTeamClient().getPunishments(new PunishmentsListRequest(user.getName(), null));
+                    if (!punishmentsListResponse.isNotFound()) {
+                        boolean altBanned = false;
+                        boolean altMuted = false;
+
+                        for (Punishment punishment : punishmentsListResponse.getPunishments()) {
+                            if ("BAN".equals(punishment.getType().toUpperCase()) && punishment.isActive()) {
+                                altBanned = true;
+                            }
+
+                            if ("MUTE".equals(punishment.getType().toUpperCase()) && punishment.isActive()) {
+                                altMuted = true;
+                            }
+                        }
+
+                        if (altBanned) {
+                            banned = true;
+                            punishedAlts.add(ChatColor.GRAY + "- " + ChatColor.RED + user.getName());
+                        } else if (altMuted) {
+                            punishedAlts.add(ChatColor.GRAY + "- " + ChatColor.YELLOW + user.getName());
+                        }
+                    }
+                }
+
+                if (punishedAlts.isEmpty()) return;
+
+                String staffNotification = ChatColor.DARK_RED + "[STAFF] " + (banned ? ChatColor.RED : ChatColor.YELLOW) +
+                        event.getPlayer().getName() + " might be " + (banned ? "ban" : "mute") + "-evading";
+
+                TextComponent message = new TextComponent(staffNotification);
+
+                TextComponent[] hoverMessage = new TextComponent[punishedAlts.size()];
+                for (int i = 0; i < punishedAlts.size(); i++) {
+                    hoverMessage[i] = new TextComponent(punishedAlts.get(i));
+                }
+
+                message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverMessage));
+
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (player.hasPermission("tgm.lookup")) {
+                        player.spigot().sendMessage(message);
+                    }
+                }
+                Bukkit.getConsoleSender().sendMessage(message);
+            }
+        });
     }
 
     //TODO: Persistent modules


### PR DESCRIPTION
Checks alts whenever a player joins and sends a staff message when at least one muted or banned alt is found. A list of muted/banned alts can be seen when hovering over the message. Muted alts are marked yellow, banned ones are marked red.

Bans color-override mutes just like in https://github.com/Warzone/TGM/pull/651

This also marks online players green (overridden by active mutes and bans) in /alts and solves https://github.com/Warzone/TGM/issues/589 completely except for showing the active punishment by hovering over a name in /alts.