### PR TITLE
Add "c" as a /chat alias.

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -342,7 +342,7 @@ public class PunishCommands {
         });
     }
 
-    @Command(aliases = {"chat"}, desc = "Control chat settings", min = 1, usage = "(mute|clear)")
+    @Command(aliases = {"chat", "c"}, desc = "Control chat settings", min = 1, usage = "(mute|clear)")
     @CommandPermissions({"tgm.chat.control"})
     public static void chat(CommandContext cmd, CommandSender sender) {
         String action = cmd.getString(0);


### PR DESCRIPTION
This is in reference to https://github.com/benrobson/Docs/issues/6
Another plugin uses /chat which allows us not to use /chat on the TGM side.