### PR TITLE
Force nick length

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public class NickCommands {
 
-    private static final String NAME_REGEX = "^[a-z_A-Z0-9]+$";
+    private static final String NAME_REGEX = "^[a-z_A-Z0-9]{1,16}$";
 
     @Command(aliases = {"nicks"}, desc = "View all nicked players", max = 1)
     @CommandPermissions({"tgm.command.whois"})


### PR DESCRIPTION
After *careful* experimentation, I have deduced that having an 18 character nickname will kick everyone online and prevent you from rejoining the server. To hopefully prevent people from doing it in the future, here is a pull request that should hopefully counter this tragic oversight.