### PR TITLE
Shuffle Rotations flag.

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
@@ -1,15 +1,36 @@
 package network.warzone.tgm.map;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-@AllArgsConstructor
-@Getter
 public class Rotation {
-    private final String name;
-    private final boolean isDefault;
-    private final RotationRequirement requirements;
-    private final List<MapContainer> maps;
+    @Getter private final String name;
+    @Getter private final boolean isDefault;
+    @Getter private final RotationRequirement requirements;
+    private final List<MapContainer> baseMaps;
+    private List<MapContainer> activeMaps;
+
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps) {
+        this.name = name;
+        this.isDefault = isDefault;
+        this.requirements = requirements;
+        this.baseMaps = baseMaps;
+        this.activeMaps = new ArrayList<>(baseMaps);
+    }
+
+    public List<MapContainer> getMaps() {
+        return this.activeMaps;
+
+    }
+
+    public void shuffleMaps() {
+        Collections.shuffle(this.activeMaps);
+    }
+
+    public void unshuffleMaps() {
+        this.activeMaps = new ArrayList<>(this.baseMaps);
+    }
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
@@ -14,16 +14,20 @@ public class Rotation {
     private List<MapContainer> activeMaps;
 
     public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps) {
+        this(name, isDefault, requirements, baseMaps, false);
+    }
+
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, final boolean initialShuffle) {
         this.name = name;
         this.isDefault = isDefault;
         this.requirements = requirements;
         this.baseMaps = baseMaps;
         this.activeMaps = new ArrayList<>(baseMaps);
+        if (initialShuffle) this.shuffleMaps();
     }
 
     public List<MapContainer> getMaps() {
         return this.activeMaps;
-
     }
 
     public void shuffleMaps() {

--- a/TGM/src/main/java/network/warzone/tgm/map/RotationDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/RotationDeserializer.java
@@ -18,6 +18,11 @@ public class RotationDeserializer implements JsonDeserializer<Rotation> {
             isDefault = json.get("default").getAsBoolean();
         }
 
+        boolean initialShuffle = false;
+        if (json.has("shuffle")) {
+            initialShuffle = json.get("shuffle").getAsBoolean();
+        }
+
         RotationRequirement requirements = new RotationRequirement(0, 999999);
         if (json.has("requirements")) {
             requirements = TGM.get().getGson().fromJson(json.get("requirements").getAsJsonObject(), RotationRequirement.class);
@@ -32,6 +37,6 @@ public class RotationDeserializer implements JsonDeserializer<Rotation> {
             }
         }
 
-        return new Rotation(name, isDefault, requirements, maps);
+        return new Rotation(name, isDefault, requirements, maps, initialShuffle);
     }
 }


### PR DESCRIPTION
I recently bought this suggestion to Tank's attention and a few days later Panda created #687.
This would make the beginning maps not stale and still keeping rotations fresh in a sense.

I have tested this branch and PR and it works as intended.
Adding `"shuffle": true,` to the rotation will shuffle all maps as intended.