### PR TITLE
Add Kit Layout Editor

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -76,6 +76,8 @@ public class MiscCommands {
         KitEditorModule kitEditorModule = TGM.get().getModule(KitEditorModule.class);
         if ("on".equalsIgnoreCase(commandContext.getString(0))) {
             KitEditorModule.setEnabled(true);
+            kitEditorModule.load();
+            if (KitEditorModule.isKitEditable()) kitEditorModule.applyItem();
             sender.sendMessage(ChatColor.GREEN + "Enabled kit layout editing.");
         } else if ("off".equalsIgnoreCase(commandContext.getString(0))) {
             KitEditorModule.setEnabled(false);

--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -84,6 +84,7 @@ public class MiscCommands {
         } else {
             sender.sendMessage(ChatColor.RED + "/kiteditor <on|off>");
         }
+    }
 
     @Command(aliases = {"rules"}, desc = "View the server rules.")
     public static void rules(CommandContext commandContext, CommandSender sender) {

--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -5,6 +5,7 @@ import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.kit.KitEditorModule;
 import network.warzone.tgm.nickname.ProfileCache;
 import network.warzone.tgm.util.Players;
 import network.warzone.tgm.util.ServerUtil;
@@ -66,6 +67,22 @@ public class MiscCommands {
         if ("clear".equalsIgnoreCase(commandContext.getString(0))) {
             ProfileCache.getInstance().clear();
             sender.sendMessage(ChatColor.YELLOW + "Cleared the profile cache.");
+        }
+    }
+
+    @Command(aliases = {"kiteditor", "ke"}, desc = "Manages the kit layout editor", usage = "<on|off>", min = 1)
+    @CommandPermissions({"tgm.kiteditor.manage"})
+    public static void kitEditor(CommandContext commandContext, CommandSender sender) {
+        KitEditorModule kitEditorModule = TGM.get().getModule(KitEditorModule.class);
+        if ("on".equalsIgnoreCase(commandContext.getString(0))) {
+            KitEditorModule.setEnabled(true);
+            sender.sendMessage(ChatColor.GREEN + "Enabled kit layout editing.");
+        } else if ("off".equalsIgnoreCase(commandContext.getString(0))) {
+            KitEditorModule.setEnabled(false);
+            kitEditorModule.unload();
+            sender.sendMessage(ChatColor.GREEN + "Disabled kit layout editing.");
+        } else {
+            sender.sendMessage(ChatColor.RED + "/kiteditor <on|off>");
         }
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -14,6 +14,7 @@ import network.warzone.tgm.modules.death.DeathModule;
 import network.warzone.tgm.modules.filter.FilterManagerModule;
 import network.warzone.tgm.modules.generator.GeneratorModule;
 import network.warzone.tgm.modules.killstreak.KillstreakModule;
+import network.warzone.tgm.modules.kit.KitEditorModule;
 import network.warzone.tgm.modules.kit.KitLoaderModule;
 import network.warzone.tgm.modules.kit.classes.GameClassModule;
 import network.warzone.tgm.modules.knockback.KnockbackModule;
@@ -69,6 +70,7 @@ public abstract class MatchManifest {
         modules.add(new RegionManagerModule());
         modules.add(new TaskedModuleManager());
         modules.add(new CountdownManagerModule());
+        modules.add(new KitEditorModule());
         modules.add(new KitLoaderModule());
         modules.add(new DeathModule());
         modules.add(new DeathMessageModule());

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
@@ -102,7 +102,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
                 if (matchTeam.isSpectator()) {
                     spectatorModule.applySpectatorKit(playerContext);
                 } else if (reset) {
-                    if (KitEditorModule.isEnabled() && kitEditorModule.isKitEditable() && kitEditorModule.getEditorMenus().containsKey(playerContext.getPlayer().getUniqueId())) {
+                    if (KitEditorModule.isEnabled() && KitEditorModule.isKitEditable() && kitEditorModule.getEditorMenus().containsKey(playerContext.getPlayer().getUniqueId())) {
                         KitEditorMenu kitEditorMenu = kitEditorModule.getEditorMenus().get(playerContext.getPlayer().getUniqueId());
                         kitEditorMenu.getKit().apply(playerContext.getPlayer(), matchTeam);
                     } else {

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -50,12 +50,11 @@ public class SpectatorModule extends MatchModule implements Listener {
     private TeamManagerModule teamManagerModule;
 
     private MatchTeam spectators;
-    private PublicMenu teamSelectionMenu;
+    private final PublicMenu teamSelectionMenu;
 
     private final ItemStack compassItem;
     private final ItemStack teamSelectionItem;
     private final ItemStack teleportMenuItem;
-    private final ItemStack kitEditorItem;
 
     private final ItemStack leatherHelmet;
 
@@ -72,7 +71,6 @@ public class SpectatorModule extends MatchModule implements Listener {
         compassItem = ItemFactory.createItem(Material.COMPASS, ChatColor.YELLOW + "Teleport Tool");
         teamSelectionItem = ItemFactory.createItem(Material.NETHER_STAR, ChatColor.YELLOW + "Team Selection");
         teleportMenuItem = ItemFactory.createItem(Material.CLOCK, ChatColor.YELLOW + "Player Teleport");
-        kitEditorItem = ItemFactory.createItem(Material.CHEST, ChatColor.YELLOW + "Kit Editor");
 
         leatherHelmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta leatherHelmetMeta = (LeatherArmorMeta) leatherHelmet.getItemMeta();
@@ -136,14 +134,10 @@ public class SpectatorModule extends MatchModule implements Listener {
         playerContext.getPlayer().getInventory().setItem(2, compassItem);
         playerContext.getPlayer().getInventory().setItem(4, teamSelectionItem);
         playerContext.getPlayer().getInventory().setItem(6, teleportMenuItem);
-
-        if (kitEditorModule.isEnabled() && kitEditorModule.isKitEditable()) {
-            playerContext.getPlayer().getInventory().setItem(8, kitEditorItem);
-        }
+        // Inventory slot 8 is reserved for the kitEditorItem in KitLoaderModule
 
         playerContext.getPlayer().getInventory().setHeldItemSlot(4);
     }
-
 
     private void updateTeamMenuItem(MatchTeam matchTeam, int i) {
         ItemStack itemStack = new ItemStack(Material.LEATHER_HELMET);
@@ -369,8 +363,8 @@ public class SpectatorModule extends MatchModule implements Listener {
                 }
                 teleportMenu.open(event.getPlayer());
                 players.clear();
-            } else if (event.getItem().isSimilar(kitEditorItem)) {
-                if (KitEditorModule.isEnabled()) {
+            } else if (event.getItem().isSimilar(kitEditorModule.getKitEditorItem())) {
+                if (KitEditorModule.isEnabled() && KitEditorModule.isKitEditable()) {
                     KitEditorMenu kitEditor;
                     if (kitEditorModule.getEditorMenus().containsKey(event.getPlayer().getUniqueId())) {
                         kitEditor = kitEditorModule.getEditorMenus().get(event.getPlayer().getUniqueId());

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
@@ -2,33 +2,78 @@ package network.warzone.tgm.modules.kit;
 
 import lombok.Getter;
 import lombok.Setter;
+import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.match.ModuleData;
+import network.warzone.tgm.match.ModuleLoadTime;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamChangeEvent;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.user.PlayerContext;
+import network.warzone.tgm.util.itemstack.ItemFactory;
 import network.warzone.tgm.util.menu.KitEditorMenu;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.UUID;
 
-public class KitEditorModule extends MatchModule {
+@ModuleData(load = ModuleLoadTime.LATER)
+public class KitEditorModule extends MatchModule implements Listener {
 
-    @Getter
-    @Setter
-    private boolean isKitEditable = true;
+    @Getter private final ItemStack kitEditorItem;
 
-    @Getter
-    @Setter
-    private static boolean enabled = true;
+    @Getter @Setter private static boolean enabled = true;
+    @Getter @Setter private static boolean isKitEditable = true;
 
-    @Getter
-    private HashMap<UUID, KitEditorMenu> editorMenus;
+    @Getter private HashMap<UUID, KitEditorMenu> editorMenus;
 
-    @Override
-    public void load(Match match) {
+    public KitEditorModule() {
+        kitEditorItem = ItemFactory.createItem(Material.CHEST, ChatColor.YELLOW + "Kit Editor");
+    }
+
+    public void load() {
         editorMenus = new HashMap<>();
     }
 
     @Override
+    public void load(Match match) {
+        load();
+    }
+
+    @Override
     public void unload() {
+        for (MatchTeam matchTeam : TGM.get().getModule(TeamManagerModule.class).getTeams()) {
+            if (!matchTeam.isSpectator()) continue;
+            for (PlayerContext player : matchTeam.getMembers()) {
+                player.getPlayer().getInventory().clear(8);
+            }
+        }
+
+        for (KitEditorMenu menu : editorMenus.values()) {
+            menu.disable();
+        }
+
         editorMenus.clear();
+    }
+
+    public void applyItem() {
+        for (MatchTeam matchTeam : TGM.get().getModule(TeamManagerModule.class).getTeams()) {
+            if (!matchTeam.isSpectator()) continue;
+            for (PlayerContext player : matchTeam.getMembers()) {
+                player.getPlayer().getInventory().setItem(8, kitEditorItem);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onChange(TeamChangeEvent event) {
+        if (!event.getTeam().isSpectator() || !enabled || !isKitEditable) return;
+
+        applyItem();
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
@@ -1,0 +1,34 @@
+package network.warzone.tgm.modules.kit;
+
+import lombok.Getter;
+import lombok.Setter;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.util.menu.KitEditorMenu;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class KitEditorModule extends MatchModule {
+
+    @Getter
+    @Setter
+    private boolean isKitEditable = true;
+
+    @Getter
+    @Setter
+    private static boolean enabled = true;
+
+    @Getter
+    private HashMap<UUID, KitEditorMenu> editorMenus;
+
+    @Override
+    public void load(Match match) {
+        editorMenus = new HashMap<>();
+    }
+
+    @Override
+    public void unload() {
+        editorMenus.clear();
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
@@ -31,7 +31,9 @@ public class KitLoaderModule extends MatchModule {
     @Override
     public void load(Match match) {
         KitEditorModule kitEditorModule = match.getModule(KitEditorModule.class);
-        int i = 0;
+        kitEditorModule.setKitEditable(match.getMapContainer().getMapInfo().getJsonObject().has("kits")
+                && match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("kits").size() == 1);
+
         if (match.getMapContainer().getMapInfo().getJsonObject().has("kits")) {
             TeamManagerModule teamManagerModule = match.getModule(TeamManagerModule.class);
 
@@ -92,10 +94,7 @@ public class KitLoaderModule extends MatchModule {
                 for (MatchTeam matchTeam : teams) {
                     matchTeam.addKit(kit);
                 }
-
-                i++;
             }
         }
-        kitEditorModule.setKitEditable(i == 1); // Only allow kit editing if there is one single kit
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
@@ -12,7 +12,6 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class KitLoaderModule extends MatchModule {
 
     //@Getter private final List<KitNodeParser> parsers = new ArrayList<>();
@@ -32,6 +31,10 @@ public class KitLoaderModule extends MatchModule {
     @Override
     public void load(Match match) {
         if (match.getMapContainer().getMapInfo().getJsonObject().has("kits")) {
+            TeamManagerModule teamManagerModule = match.getModule(TeamManagerModule.class);
+            KitEditorModule kitEditorModule = match.getModule(KitEditorModule.class);
+
+            int i = 0;
             for (JsonElement kitElement : match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("kits")) {
                 JsonObject kitJson = kitElement.getAsJsonObject();
 
@@ -46,7 +49,6 @@ public class KitLoaderModule extends MatchModule {
                 }
 
                 List<MatchTeam> teams = new ArrayList<>();
-                TeamManagerModule teamManagerModule = match.getModule(TeamManagerModule.class);
                 if (kitJson.has("teams")) {
                     for (JsonElement jsonElement : kitJson.getAsJsonArray("teams")) {
                         if (!jsonElement.isJsonPrimitive()) continue;
@@ -91,7 +93,9 @@ public class KitLoaderModule extends MatchModule {
                     matchTeam.addKit(kit);
                 }
 
+                i++;
             }
+            kitEditorModule.setKitEditable(i == 1); // Only allow kit editing if there is one single kit
         }
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
@@ -30,8 +30,7 @@ public class KitLoaderModule extends MatchModule {
 
     @Override
     public void load(Match match) {
-        KitEditorModule kitEditorModule = match.getModule(KitEditorModule.class);
-        kitEditorModule.setKitEditable(match.getMapContainer().getMapInfo().getJsonObject().has("kits")
+        KitEditorModule.setKitEditable(match.getMapContainer().getMapInfo().getJsonObject().has("kits")
                 && match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("kits").size() == 1);
 
         if (match.getMapContainer().getMapInfo().getJsonObject().has("kits")) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitLoaderModule.java
@@ -30,11 +30,11 @@ public class KitLoaderModule extends MatchModule {
 
     @Override
     public void load(Match match) {
+        KitEditorModule kitEditorModule = match.getModule(KitEditorModule.class);
+        int i = 0;
         if (match.getMapContainer().getMapInfo().getJsonObject().has("kits")) {
             TeamManagerModule teamManagerModule = match.getModule(TeamManagerModule.class);
-            KitEditorModule kitEditorModule = match.getModule(KitEditorModule.class);
 
-            int i = 0;
             for (JsonElement kitElement : match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("kits")) {
                 JsonObject kitJson = kitElement.getAsJsonObject();
 
@@ -95,7 +95,7 @@ public class KitLoaderModule extends MatchModule {
 
                 i++;
             }
-            kitEditorModule.setKitEditable(i == 1); // Only allow kit editing if there is one single kit
         }
+        kitEditorModule.setKitEditable(i == 1); // Only allow kit editing if there is one single kit
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
@@ -1,0 +1,188 @@
+package network.warzone.tgm.util.menu;
+
+import lombok.Getter;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.kit.Kit;
+import network.warzone.tgm.modules.kit.KitNode;
+import network.warzone.tgm.modules.kit.types.ItemKitNode;
+import network.warzone.tgm.util.itemstack.ItemFactory;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Created by Atdit on 24/04/2020
+ */
+public class KitEditorMenu implements Listener {
+    @Getter private final Inventory inventory;
+
+    @Getter
+    private Kit kit;
+
+    private final HashMap<Integer, MenuAction> actions = new HashMap<>();
+
+    public KitEditorMenu(List<Kit> kits, String mapName) {
+        String name = ChatColor.UNDERLINE + "Kit Editor:" + ChatColor.RESET + " " + mapName;
+        int slots = 5 * 9;
+
+        this.inventory = Bukkit.createInventory(null, slots, name);
+        TGM.registerEvents(this);
+
+        kit = kits.get(0); // Only runs if there is one kit
+
+        ItemStack saveItem = ItemFactory.createItem(Material.LIME_TERRACOTTA, ChatColor.GREEN + "Save");
+        setItem(0, saveItem, (player, event) -> {
+            saveKit();
+            player.sendMessage(ChatColor.GREEN + "Saved kit!");
+            player.closeInventory();
+        });
+
+        ItemStack cancelItem = ItemFactory.createItem(Material.RED_TERRACOTTA, ChatColor.RED + "Cancel");
+        setItem(1, cancelItem, (player, event) -> {
+            player.closeInventory();
+        });
+    }
+
+    public void open(Player player) {
+        loadKit();
+        player.openInventory(inventory);
+    }
+
+    private void saveKit() {
+        List<KitNode> kitNodes = new ArrayList<>();
+
+        List<ItemKitNode> itemKitNodes = new ArrayList<>();
+
+        for (int slot = 9; slot < 45; slot++) {
+            ItemStack itemStack = inventory.getItem(slot);
+
+            if (itemStack != null) {
+                ItemKitNode itemKitNode = new ItemKitNode((slot < 36 ? slot : slot - 36), itemStack, false);
+                itemKitNodes.add(itemKitNode);
+            }
+        }
+
+        for (KitNode kitNode : kit.getNodes()) {
+            if (!(kitNode instanceof ItemKitNode)) {
+                kitNodes.add(kitNode);
+            } else {
+                ItemKitNode itemKitNode = (ItemKitNode) kitNode;
+                if (itemKitNode.getSlot() < 0 || itemKitNode.getSlot() > 35) {
+                    kitNodes.add(itemKitNode);
+                }
+            }
+        }
+
+        kitNodes.addAll(itemKitNodes);
+
+        kit = new Kit(kit.getName(), kit.getDescription(), kitNodes);
+    }
+
+    private void loadKit() {
+        clearKit();
+
+        kit.getNodes().forEach(kitNode -> {
+            if (kitNode instanceof ItemKitNode) {
+                ItemKitNode itemKitNode = (ItemKitNode) kitNode;
+
+                int slot = itemKitNode.getSlot();
+
+                if (slot >= 0 && slot <= 8) {
+                    setItem(slot + 36, itemKitNode.getItemStack());
+                } else if (slot >= 9 && slot <= 35) {
+                    setItem(slot, itemKitNode.getItemStack());
+                }
+            }
+        });
+    }
+
+    private void setItem(int slot, ItemStack itemStack, MenuAction action) {
+        this.setItem(slot, itemStack);
+        if (action != null) {
+            this.actions.put(slot, action);
+        }
+    }
+
+    private void setItem(int slot, ItemStack itemStack) {
+        this.inventory.setItem(slot, itemStack);
+    }
+
+    private void clearKit() {
+        for (int slot = 9; slot < 45; slot++) {
+            inventory.setItem(slot, null);
+        }
+    }
+
+    public void disable() {
+        HandlerList.unregisterAll(this);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onClick(InventoryClickEvent event) {
+        if (!event.getInventory().equals(inventory)) return;
+
+        Player player = (Player) event.getWhoClicked();
+
+        if (event.getRawSlot() > 44) {
+            event.setCancelled(true);
+        }
+
+        if (event.getRawSlot() <= 8) {
+            event.setCancelled(true);
+
+            if (event.getCursor() == null || event.getCursor().getType() == Material.AIR) {
+                if (this.actions.containsKey(event.getSlot())) {
+                    this.actions.get(event.getSlot()).run(player, event);
+                }
+            } else {
+                player.sendMessage(ChatColor.RED + "You can't place the item here.");
+            }
+            return;
+        }
+
+        if (event.getAction() != InventoryAction.PICKUP_ALL && event.getAction() != InventoryAction.PLACE_ALL && event.getAction() != InventoryAction.SWAP_WITH_CURSOR) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDrag(InventoryDragEvent event) {
+        if (!event.getInventory().equals(inventory)) return;
+
+        if (event.getRawSlots().size() > 1) {
+            event.setCancelled(true);
+        }
+
+        for (int slot : event.getRawSlots()) {
+            if (slot < 9 || slot > 44) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onClose(InventoryCloseEvent event) {
+        if (!event.getInventory().equals(inventory)) return;
+
+        Bukkit.getScheduler().runTask(TGM.get(), () -> {
+            event.getPlayer().getInventory().clear(0);
+        });
+
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
@@ -183,6 +183,5 @@ public class KitEditorMenu implements Listener {
         Bukkit.getScheduler().runTask(TGM.get(), () -> {
             event.getPlayer().getInventory().clear(0);
         });
-
     }
 }


### PR DESCRIPTION
Adds the ability of spectators to edit the kit layout if using an interactive chest item if:
- the map does not use the hardcoded kits from the GameClassModule
- the map does not have more than one kit (which applies to 97% of the maps in the rotation the time of commiting this)
- the kit editor module is not disabled

The kit editor module can be disabled globally using /kiteditor off in case there is an unexpected game-breaking bug. The normal kits will be given out instead. All edited kits will be deleted.

The code changes have been tested a lot. No duplication bugs or error throwings in the console were found.

The kits are only saved for the current ongoing map, since there is no way to save settings on a user level on the API yet. All edited kits will be unloaded in the cycling process.


Pictures:

![2021-01-17_15 35 46](https://user-images.githubusercontent.com/7355350/104846266-f070bd80-58d9-11eb-946a-8c41f6ac9eed.png)
The kit editor menu which can be opened only as a spectator. Items can't be duplicated or dropped from it.

![2021-01-17_15 36 05](https://user-images.githubusercontent.com/7355350/104846288-0b433200-58da-11eb-875b-2e98dab0f7c7.png)
The kit is only saved if the "Save" item is clicked, otherwise the kit layout stays what it was before.

![2021-01-17_15 36 23](https://user-images.githubusercontent.com/7355350/104846307-2150f280-58da-11eb-8a35-fd0a336b159e.png)
The kit layout after editing it

![2021-01-17_15 36 42](https://user-images.githubusercontent.com/7355350/104846315-29109700-58da-11eb-93d1-73d13beaa732.png)
On maps with more than one kit (perhaps due to team specific items like colored glass or clay blocks), the kit editor is disabled and doesn't appear in the spectator inventory. In the current Warzone rotation, this only happens on two maps: Aerial Conquest and Aequabilis. On such maps, the normal layout is loaded.