### PR TITLE
Broadcast /setnext to all players

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -232,7 +232,7 @@ public class CycleCommands {
         sender.sendMessage(ChatColor.GREEN + "Countdowns cancelled.");
     }
 
-    @Command(aliases = {"setnext", "sn"}, desc = "Set the next map.")
+    @Command(aliases = {"setnext", "sn"}, desc = "Set the next map.", anyFlags = true, flags = "s")
     @CommandPermissions({"tgm.setnext"})
     public static void setNext(CommandContext cmd, CommandSender sender) {
         if (cmd.argsLength() > 0) {
@@ -257,9 +257,15 @@ public class CycleCommands {
             }
 
             TGM.get().getMatchManager().setForcedNextMap(found);
-            sender.sendMessage(ChatColor.GREEN + "Set the next map to " + ChatColor.YELLOW + found.getMapInfo().getName() + ChatColor.GRAY + " (" + found.getMapInfo().getVersion() + ")");
+
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (!cmd.hasFlag('s') || player.hasPermission("tgm.setnext")) {
+                    player.sendMessage(ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + " set the next map to " +
+                            ChatColor.YELLOW + found.getMapInfo().getName() + ChatColor.GRAY + " (" + found.getMapInfo().getVersion() + ")");
+                }
+            }
         } else {
-            sender.sendMessage(ChatColor.RED + "/sn <map_name>");
+            sender.sendMessage(ChatColor.RED + "/sn [-s] <map_name>");
         }
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -258,11 +258,10 @@ public class CycleCommands {
 
             TGM.get().getMatchManager().setForcedNextMap(found);
 
-            for (Player player : Bukkit.getOnlinePlayers()) {
-                if (!cmd.hasFlag('s') || player.hasPermission("tgm.setnext")) {
-                    player.sendMessage(ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + " set the next map to " +
-                            ChatColor.YELLOW + found.getMapInfo().getName() + ChatColor.GRAY + " (" + found.getMapInfo().getVersion() + ")");
-                }
+            boolean announceToEveryone = !cmd.hasFlag('s');
+            for (Player player : Bukkit.getOnlinePlayers().stream().filter((player) -> announceToEveryone || player.hasPermission("tgm.setnext")).collect(Collectors.toSet())) {
+                player.sendMessage(ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + " set the next map to " +
+                        ChatColor.YELLOW + found.getMapInfo().getName() + ChatColor.GRAY + " (" + found.getMapInfo().getVersion() + ")");
             }
         } else {
             sender.sendMessage(ChatColor.RED + "/sn [-s] <map_name>");


### PR DESCRIPTION
If a map has been found after using /setnext, instead of only telling the sender the map has been set, it will instead by default broadcast it to everyone on the server.

The flag "-s" can be used to set the next map silently, resulting in only the sender and everyone with the permission to run the command to see the broadcast. If used, the flag must be added before the map name. Example: /sn -s Itty Bitty

Screenshot:
![image](https://user-images.githubusercontent.com/7355350/105420583-eab00a80-5c40-11eb-9267-0bec450f994c.png)

Tested and worked just fine