### PR TITLE
Fix incorrect team size calculation for Blitz

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -216,7 +216,8 @@ public class BlitzModule extends MatchModule implements Listener {
 
     private void handleQuit(PlayerEvent event) {
         if ((teamManagerModule.getTeam(event.getPlayer()) != null && teamManagerModule.getTeam(event.getPlayer()).isSpectator())) return;
-        updateScoreboardTeamLine(teamManagerModule.getTeam(event.getPlayer()), getAlivePlayers(teamManagerModule.getTeam(event.getPlayer())).size() - 1);
+        playerLives.remove(event.getPlayer().getUniqueId());
+        updateScoreboardTeamLine(teamManagerModule.getTeam(event.getPlayer()), getAlivePlayers(teamManagerModule.getTeam(event.getPlayer())).size());
 
         if (!TGM.get().getMatchManager().getMatch().getMatchStatus().equals(MatchStatus.MID)) return;
 


### PR DESCRIPTION
There is a bug in the Blitz mode where the scoreboard will show an incorrect team size. This is because of a case it does not consider when quitting. Consider a participating player quits: the player may be alive or dead. If they are alive, the procedure will correctly update the sidebar with (size of alive players - 1). However, if the player is dead, (size of alive players - 1) is not correct, since the size of alive players does not change when a dead player leaves. This is often why the scoreboard will show 1 less than the actual amount.

This PR will instead mutate the lives Map which will delete the lives entry for the player when they quit, as the size of alive players is derived from entries in this map. 

Not tested but should work