### PR TITLE
Alts enhancements #3

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -216,6 +216,7 @@ public class PunishCommands {
                 }
                 for (Punishment punishment : punishmentsListResponse.getPunishments()) {
                     if (restrictedView) {
+                        if (!map.get(punishment.getPunished()).equalsIgnoreCase(displayName)) continue;
                         sender.spigot().sendMessage(restrictedPunishmentToTextComponent(punishment, map.get(punishment.getPunished())));
                     } else {
                         sender.spigot().sendMessage(punishmentToTextComponent(punishment, map.get(punishment.getPunished()), map.getOrDefault(punishment.getPunisher(), "Console"), true));
@@ -302,19 +303,30 @@ public class PunishCommands {
 
                     PunishmentsListResponse punishmentsListResponse = TGM.get().getTeamClient().getPunishments(new PunishmentsListRequest(user.getName(), null));
                     if (!punishmentsListResponse.isNotFound()) {
+                        HashMap<ObjectId, String> map = new HashMap<>();
+                        for (PunishmentsListResponse.LoadedUser loadedUser : punishmentsListResponse.getLoadedUsers()) {
+                            map.put(loadedUser.getId(), loadedUser.getName());
+                        }
+
                         for (Punishment punishment : punishmentsListResponse.getPunishments()) {
-                            if ("BAN".equals(punishment.getType().toUpperCase()) && punishment.isActive()) {
+                            if (!map.get(punishment.getPunished()).equalsIgnoreCase(user.getName())) continue;
+
+                            if ("BAN".equalsIgnoreCase(punishment.getType()) && punishment.isActive()) {
                                 isBanned = true;
                                 break;
                             }
 
-                            if ("MUTE".equals(punishment.getType().toUpperCase()) && punishment.isActive()) {
+                            if ("MUTE".equalsIgnoreCase(punishment.getType()) && punishment.isActive()) {
                                 isMuted = true;
                             }
                         }
                     }
 
                     ChatColor chatColor = ChatColor.WHITE;
+
+                    if (Bukkit.getPlayer(user.getName()) != null) {
+                        chatColor = ChatColor.GREEN;
+                    }
 
                     if (isMuted) {
                         chatColor = ChatColor.YELLOW;


### PR DESCRIPTION
Since recently, /punishments shows us a list of a user's punishments as well as all the punishments on the user's IP. This change made /alts mark alt account names as yellow and red as well, while they might not be currently muted or banned, but have an alt which is.

This pulll request changes the following:
- Checks while iterating through the punishments of every alt, whether the punishment.getPunished() equals the alt name which is currently checked. If it does not, it continues with the next punishment.

- Checks the same while iterating through the punishments in the /punishments command, and doesn't list those punishments if the view is restricted (user does not have "tgm.punish.list")

- Checks for every alt in /alts if the player is online, and if so, marks the name green, just like in #668. It is overwritten by active mutes and bans.

Tested.

![image](https://user-images.githubusercontent.com/7355350/106157222-c2656600-6182-11eb-93a2-58b52f05b7e1.png)
Marks online alts as green, unless they are muted (yellow). Banned alts obviously wouldn't be online.

![image](https://user-images.githubusercontent.com/7355350/106157560-225c0c80-6183-11eb-9844-28b110674fbb.png)
Restricted /punishments view doesn't allow punishments of the same IP to be seen, only of the same name.

![image](https://user-images.githubusercontent.com/7355350/106157621-2f78fb80-6183-11eb-8bb8-9d16b04c13da.png)
Unrestricted /punishments view still allows punishments of the same IP to be seen
