### PR TITLE
Prevent unintentional wool chests

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/wool/WoolChestModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/wool/WoolChestModule.java
@@ -45,6 +45,7 @@ public class WoolChestModule extends MatchModule implements Listener {
     public void unload() {
         Bukkit.getScheduler().cancelTask(runnableId);
         woolChests.clear();
+        disqualifiedChests.clear();
     }
 
     @EventHandler
@@ -102,6 +103,7 @@ public class WoolChestModule extends MatchModule implements Listener {
                     event.getPlayer().sendMessage(ChatColor.RED + "You cannot break the wool chest!");
                 }
             }
+            if (!event.isCancelled()) disqualifiedChests.remove(event.getBlock().getLocation());
         }
     }
 


### PR DESCRIPTION
Putting wool in a chest and reopening it will unintentionally make it a wool chest. To fix this, the act of placing a chest will preempt it from becoming a wool chest.

Deja vu vibes