### PR TITLE
Add killstreak to spectator player inventory

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
@@ -86,7 +86,8 @@ public class InventoryUtil {
 
     private static ItemStack getKillstreakItem(int killstreak) {
         int amount = killstreak > 64 ? 1 : killstreak;
-        return ItemFactory.createItem(Material.IRON_SWORD, ChatColor.GREEN + "Killstreak: " + ChatColor.DARK_GREEN + killstreak, amount);
+        Material material = killstreak > 64 ? Material.DIAMOND_SWORD : Material.IRON_SWORD;
+        return ItemFactory.createItem(material, ChatColor.GREEN + "Killstreak: " + ChatColor.DARK_GREEN + killstreak, amount);
     }
 
     private static ItemStack getHealthItem(Player player) {

--- a/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
@@ -2,6 +2,8 @@ package network.warzone.tgm.util;
 
 import net.minecraft.server.v1_16_R3.NBTTagList;
 import net.minecraft.server.v1_16_R3.NBTTagString;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.killstreak.KillstreakModule;
 import network.warzone.tgm.util.itemstack.Effects;
 import network.warzone.tgm.util.itemstack.ItemFactory;
 import org.bukkit.Bukkit;
@@ -68,12 +70,24 @@ public class InventoryUtil {
         }
         inventory.setItem(4, player.getInventory().getItemInOffHand());
 
+        KillstreakModule killstreakModule = TGM.get().getModule(KillstreakModule.class);
+        if (killstreakModule.getKillstreak(player.getUniqueId().toString()) > 0) {
+            inventory.setItem(6, getKillstreakItem(player));
+        }
+
         inventory.setItem(7, getHealthItem(player));
         inventory.setItem(8, getPotionsItem(player.getActivePotionEffects()));
     }
 
     public static Color colorFromTime() {
         return Color.fromRGB(0);
+    }
+
+    private static ItemStack getKillstreakItem(Player player) {
+        KillstreakModule killstreakModule = TGM.get().getModule(KillstreakModule.class);
+        int killstreak = killstreakModule.getKillstreak(player.getUniqueId().toString());
+        int amount = killstreak > 64 ? 1 : killstreak;
+        return ItemFactory.createItem(Material.IRON_SWORD, ChatColor.GREEN + "Killstreak: " + ChatColor.DARK_GREEN + killstreak, amount);
     }
 
     private static ItemStack getHealthItem(Player player) {

--- a/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
@@ -71,8 +71,9 @@ public class InventoryUtil {
         inventory.setItem(4, player.getInventory().getItemInOffHand());
 
         KillstreakModule killstreakModule = TGM.get().getModule(KillstreakModule.class);
-        if (killstreakModule.getKillstreak(player.getUniqueId().toString()) > 0) {
-            inventory.setItem(6, getKillstreakItem(player));
+        int killstreak = killstreakModule.getKillstreak(player.getUniqueId().toString());
+        if (killstreak > 0) {
+            inventory.setItem(6, getKillstreakItem(killstreak));
         }
 
         inventory.setItem(7, getHealthItem(player));
@@ -83,9 +84,7 @@ public class InventoryUtil {
         return Color.fromRGB(0);
     }
 
-    private static ItemStack getKillstreakItem(Player player) {
-        KillstreakModule killstreakModule = TGM.get().getModule(KillstreakModule.class);
-        int killstreak = killstreakModule.getKillstreak(player.getUniqueId().toString());
+    private static ItemStack getKillstreakItem(int killstreak) {
         int amount = killstreak > 64 ? 1 : killstreak;
         return ItemFactory.createItem(Material.IRON_SWORD, ChatColor.GREEN + "Killstreak: " + ChatColor.DARK_GREEN + killstreak, amount);
     }

--- a/TGM/src/main/java/network/warzone/tgm/util/itemstack/ItemFactory.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/itemstack/ItemFactory.java
@@ -41,6 +41,13 @@ public class ItemFactory {
         return item;
     }
 
+    public static ItemStack createItem(Material material, String name, int amount) {
+        ItemStack item = createItem(material, name);
+        item.setAmount(amount);
+
+        return item;
+    }
+
     public static ItemStack createItem(Material material, String name, List<String> lore, int amount) {
         ItemStack item = createItem(material, name);
         item.setAmount(amount);


### PR DESCRIPTION
Adds a sword with the killstreak amount as title. It also sets the ItemStack amount to whatever the killstreak is, or to 1 if the killstreak is above 64. Tested.

![Screenshot_2](https://user-images.githubusercontent.com/7355350/106481989-48e4b500-64ad-11eb-98b4-b7a33575c03a.png)
