### PR TITLE
Only set new player's held item slot

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -170,6 +170,7 @@ public class JoinManager implements Listener {
             joinMsg += ChatColor.LIGHT_PURPLE + " [NEW]";
             event.getPlayer()
                     .sendTitle(new Title("", ChatColor.translateAlternateColorCodes('&', "&7Use &b/join&7 to play!")));
+            event.getPlayer().getInventory().setHeldItemSlot(4);
         }
         
         event.setJoinMessage(joinMsg);

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -135,8 +135,6 @@ public class SpectatorModule extends MatchModule implements Listener {
         playerContext.getPlayer().getInventory().setItem(4, teamSelectionItem);
         playerContext.getPlayer().getInventory().setItem(6, teleportMenuItem);
         // Inventory slot 8 is reserved for the kitEditorItem in KitLoaderModule
-
-        playerContext.getPlayer().getInventory().setHeldItemSlot(4);
     }
 
     private void updateTeamMenuItem(MatchTeam matchTeam, int i) {


### PR DESCRIPTION
Whenever you join the spectator team, you get the spectator kit which automatically sets your held item slot to 4 (the join team item). Personally, I think this is very annoying, especially when I join the spectator team to spectate hackers. I would prefer to not hold any item in my hand while spectating someone, because it's irritating and I might just accidentally click it, which would be very annoying. I also don't like switching to a another slot whenever I join the spectators. Usually when playing the game and joining the spectator team, you are on slot 0 which is the sword and doesn't contain an item in the spectator kit.

I simply removed the line from the spectator kit to the code which runs whenever a new player joins, which makes a lot more sense. When you join the spectator team, it doesn't necessarily mean you want to choose a team, so the player's held item slot shouldn't be changed.