### PR TITLE
Git maps

### DIFF
--- a/TGM/pom.xml
+++ b/TGM/pom.xml
@@ -81,6 +81,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.7.0.202003110725-r</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.2.0-SNAPSHOT</version>

--- a/TGM/src/main/java/network/warzone/tgm/TGM.java
+++ b/TGM/src/main/java/network/warzone/tgm/TGM.java
@@ -81,8 +81,8 @@ public class TGM extends JavaPlugin {
     public void onEnable() {
         instance = this;
         this.startupTime = new Date().getTime();
-        FileConfiguration fileConfiguration = getConfig();
         saveDefaultConfig();
+        FileConfiguration fileConfiguration = getConfig();
 
         gson = new GsonBuilder()
                 // TGM
@@ -147,7 +147,7 @@ public class TGM extends JavaPlugin {
         Plugins.checkSoftDependencies();
 
         matchManager.cycleNextMatch();
-        nickManager = new NickManager(); 
+        if (matchManager.getMatch() != null) nickManager = new NickManager(); 
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -11,6 +11,7 @@ import network.warzone.tgm.config.TGMConfigReloadEvent;
 import network.warzone.tgm.gametype.GameType;
 import network.warzone.tgm.map.MapContainer;
 import network.warzone.tgm.map.MapInfo;
+import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchStatus;
 import network.warzone.tgm.modules.chat.ChatChannel;
 import network.warzone.tgm.modules.chat.ChatConstant;
@@ -498,6 +499,8 @@ public class CycleCommands {
         TGM.get().getMatchManager().getMapLibrary().refreshMaps();
         TGM.get().getMatchManager().getMapRotation().refresh();
         sender.sendMessage(ChatColor.GREEN + "Refreshed map library and rotation.");
+        // Attempt to cycle to a new match, if a match does not yet exist after loading maps
+        if (TGM.get().getMatchManager().getMatch() == null) TGM.get().getMatchManager().cycleNextMatch();
     }
 
     @Command(aliases = {"channel", "chatchannel", "cc"}, desc = "Change or select a chat channel.", usage = "(all|team|staff)", min = 1)
@@ -885,7 +888,8 @@ public class CycleCommands {
     public static TextComponent mapToTextComponent(int position, MapInfo mapInfo) {
         String mapName = ChatColor.GOLD + mapInfo.getName();
 
-        if (mapInfo.equals(TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo())) {
+        Match currentMatch = TGM.get().getMatchManager().getMatch();
+        if (currentMatch != null && mapInfo.equals(currentMatch.getMapContainer().getMapInfo())) {
             mapName = ChatColor.GREEN + "" + (position + 1) + ". " + mapName;
         } else {
             mapName = ChatColor.WHITE + "" + (position + 1) + ". " + mapName;

--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -53,6 +53,10 @@ public class MiscCommands {
         if ("UPDATE".equalsIgnoreCase(action)) {
             mapLibrary.updateRemote(remote, sender);
         } else {
+            if (cmd.argsLength() == 1) {
+                sender.sendMessage(ChatColor.RED + "Please specify a remote name");
+                return;
+            }
             sendRepoData(sender, remote);
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -51,6 +51,7 @@ public class MiscCommands {
         final String remote = cmd.argsLength() == 1 ? "ALL" : cmd.getString(1);
 
         if ("UPDATE".equalsIgnoreCase(action)) {
+            sender.sendMessage(ChatColor.YELLOW + "Updating remote(s), this may take awhile...");
             mapLibrary.updateRemote(remote, sender);
         } else {
             if (cmd.argsLength() == 1) {

--- a/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/MiscCommands.java
@@ -76,8 +76,8 @@ public class MiscCommands {
         } else {
             sender.sendMessage(ChatColor.WHITE + "Local Repository Data for remote " + ChatColor.GREEN + repoData.NAME);
             sender.sendMessage("");
-            sender.sendMessage(ChatColor.WHITE + "HEAD: " + ChatColor.GREEN + repoData.HEAD_ID);
-            sender.sendMessage(ChatColor.WHITE + "HEAD Commit Message: " + ChatColor.GREEN + repoData.HEAD_MESSAGE);
+            sender.sendMessage(ChatColor.WHITE + "Latest Commit: " + ChatColor.GREEN + repoData.HEAD_ID);
+            sender.sendMessage(ChatColor.WHITE + "Latest Commit Message: " + ChatColor.GREEN + repoData.HEAD_MESSAGE);
             sender.sendMessage(ChatColor.WHITE + "Branch: " + ChatColor.GREEN + repoData.BRANCH);
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/map/MapLibrary.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapLibrary.java
@@ -1,12 +1,25 @@
 package network.warzone.tgm.map;
 
 import lombok.Getter;
+import net.md_5.bungee.api.ChatColor;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.map.source.GitRemoteMapSource;
+import network.warzone.tgm.util.AsyncHelper;
+
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 /**
  * Created by luke on 4/27/17.
@@ -15,14 +28,49 @@ import java.util.List;
 public class MapLibrary {
 
     private final List<MapContainer> maps = new ArrayList<>();
+    private final List<GitRemoteMapSource> remotes = new ArrayList<>();
     private final List<File> sources = new ArrayList<>();
     private final MapLoader mapLoader;
+    private final ReentrantLock updateRemoteLock = new ReentrantLock();
 
     public MapLibrary(FileConfiguration fileConfiguration, MapLoader mapLoader) {
-        for (String s : fileConfiguration.getConfigurationSection("map").getStringList("sources")) {
-            sources.add(new File(s));
-            Bukkit.getLogger().info("Added map source: " + s);
+        ConfigurationSection mapSection = fileConfiguration.getConfigurationSection("map");
+        ConfigurationSection remotesSection = mapSection.getConfigurationSection("remotes");
+
+        if (remotesSection != null) {
+            for (String remoteEntry : remotesSection.getKeys(false)) {
+                ConfigurationSection remoteSection = remotesSection.getConfigurationSection(remoteEntry);
+                Set<String> remoteEntryKeys = remoteSection.getKeys(false);
+                if (!remoteEntryKeys.contains("destination")) {
+                    System.out.println("There should be a destination, but one wasn't specified for the remote '" + remoteEntry + "'");
+                    continue;
+                } else if (!remoteEntryKeys.contains("uri")) {
+                    System.out.println("There should be a URI, but one wasn't specified for the remote '" + remoteEntry + "'");
+                    continue;
+                }
+
+                final String destination = remoteSection.getString("destination");
+                final String remoteURI = remoteSection.getString("uri");
+                final String branch = remoteSection.getString("branch");
+
+                File destinationDirectory = new File(destination);
+
+                if (!destinationDirectory.exists()) {
+                    destinationDirectory.mkdirs();
+                }
+                if (!destinationDirectory.isDirectory()) {
+                    System.out.println("The destination was not a valid directory, skipping remote '" + remoteEntry + "'");
+                    continue;
+                }
+
+                System.out.println("Registered remote '" + remoteEntry + "'");
+                this.remotes.add(new GitRemoteMapSource(remoteEntry, destinationDirectory, remoteURI, branch));
+            }
+            boolean updateRemotes = mapSection.getBoolean("update-remotes-on-startup", false);
+            if (updateRemotes) this.updateRemotes();
         }
+
+        this.updateSources();
 
         this.mapLoader = mapLoader;
     }
@@ -33,6 +81,73 @@ public class MapLibrary {
             List<MapContainer> loaded = mapLoader.loadMaps(source);
             Bukkit.getLogger().info("Found " + loaded.size() + " maps in source " + source);
             maps.addAll(loaded);
+        }
+    }
+
+    public void updateRemotes() {
+        this.updateRemote("ALL");
+    }
+
+    public void updateRemote(final String remote) {
+        this.updateRemote(remote, null);
+    }
+
+    public GitRemoteMapSource getRemoteByName(final String name) {
+        for (GitRemoteMapSource remoteMapSource : this.remotes) {
+            if (remoteMapSource.getSourceName().equalsIgnoreCase(name)) return remoteMapSource;
+        }
+        return null;
+    }
+
+    public void updateRemote(final String remote, @Nullable CommandSender sender) {
+        if (this.updateRemoteLock.isLocked()) {
+            if (sender != null) {
+                sender.sendMessage(ChatColor.RED + "Remotes are currently being updated already");
+            }
+            return;
+        }
+
+        boolean updateAll = "ALL".equalsIgnoreCase(remote);
+
+        List<Runnable> tasks = new ArrayList<>();
+        if (updateAll) {
+            for (GitRemoteMapSource remoteMapSource : this.remotes) {
+                tasks.add(remoteMapSource::refreshMaps);
+            }
+        } else {
+            GitRemoteMapSource remoteMapSource = this.getRemoteByName(remote);
+            if (remoteMapSource != null) tasks.add(remoteMapSource::refreshMaps);
+        }
+
+        if (tasks.size() == 0) return;
+
+        final String[] updateMessages = {"Updated sources with remotes. Do " + ChatColor.GREEN + "/loadmaps" + ChatColor.RESET + " to update maps with updated sources"};
+        Runnable callback = () -> {
+            this.updateRemoteLock.unlock();
+            for (String updateMessage : updateMessages) Bukkit.getLogger().info(updateMessage);
+        };
+        if (sender != null) {
+            callback = () -> {
+                this.updateRemoteLock.unlock();
+                sender.sendMessage(updateMessages);
+            };
+        }
+
+        AsyncHelper.taskQueueWithLock(tasks, this.updateRemoteLock, callback);
+    }
+
+    public void updateSources() {
+        this.updateSources(TGM.get().getConfig().getConfigurationSection("map").getStringList("sources"));
+    }
+
+    public void updateSources(Collection<String> dirSources) {
+        for (String s : dirSources) {
+            File sourceDirectory = new File(s);
+
+            if (!sources.contains(sourceDirectory)) {
+                sources.add(sourceDirectory);
+                Bukkit.getLogger().info("Added map source: " + s);
+            }
         }
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/MapLibrary.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapLibrary.java
@@ -117,6 +117,10 @@ public class MapLibrary {
         } else {
             GitRemoteMapSource remoteMapSource = this.getRemoteByName(remote);
             if (remoteMapSource != null) tasks.add(remoteMapSource::refreshMaps);
+            else {
+                sender.sendMessage(ChatColor.RED + "Unrecognized remote '" + remote + "'");
+                return;
+            }
         }
 
         if (tasks.size() == 0) return;

--- a/TGM/src/main/java/network/warzone/tgm/map/MapLoaderImpl.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapLoaderImpl.java
@@ -16,6 +16,7 @@ public class MapLoaderImpl implements MapLoader {
 
     @Override
     public List<MapContainer> loadMaps(File folder) {
+        if (!folder.exists()) return new ArrayList<>();
         List<MapContainer> maps = new ArrayList<>();
 
         File[] children = folder.listFiles();

--- a/TGM/src/main/java/network/warzone/tgm/map/MapRotationFile.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapRotationFile.java
@@ -29,6 +29,7 @@ public class MapRotationFile {
     }
 
     public MapContainer cycle(boolean initial) {
+        if (rotation.getMaps().size() == 0) return null;
         current = (current + (initial ? 0 : 1)) % rotation.getMaps().size();
 
         if (!rotation.isDefault() && current == rotation.getMaps().size() - 1) {
@@ -52,7 +53,7 @@ public class MapRotationFile {
         // Load rotation files
 
         if (!rotationFile.exists()) {
-            this.rotationLibrary = Collections.singletonList(new Rotation("Preset", true, new RotationRequirement(0, 999999), this.mapLibrary.getMaps()));
+            this.rotationLibrary = Collections.singletonList(new Rotation("Preset", true, new RotationRequirement(0, 999999), this.mapLibrary.getMaps(), null));
             this.rotation = this.rotationLibrary.get(0);
 
             this.current = 0;
@@ -66,6 +67,7 @@ public class MapRotationFile {
             this.rotationLibrary = Arrays.asList(rotationList);
 
             rotation = this.rotationLibrary.stream().filter(Rotation::isDefault).findFirst().orElseThrow(() -> new IllegalArgumentException("No default rotation present."));
+            rotation.refresh();
             current = this.loadRotationPosition(0);
         } catch (IOException | IllegalArgumentException e) {
             e.printStackTrace();

--- a/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
@@ -1,8 +1,10 @@
 package network.warzone.tgm.map;
 
 import lombok.Getter;
+import network.warzone.tgm.TGM;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -10,31 +12,65 @@ public class Rotation {
     @Getter private final String name;
     @Getter private final boolean isDefault;
     @Getter private final RotationRequirement requirements;
-    private final List<MapContainer> baseMaps;
+    private final Collection<String> mapNames;
+    private List<MapContainer> baseMaps;
     private List<MapContainer> activeMaps;
+    private final boolean shuffle;
 
-    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps) {
-        this(name, isDefault, requirements, baseMaps, false);
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, Collection<String> mapNames) {
+        this(name, isDefault, requirements, baseMaps, mapNames, false);
     }
 
-    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, final boolean initialShuffle) {
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, Collection<String> mapNames, final boolean shuffle) {
         this.name = name;
         this.isDefault = isDefault;
         this.requirements = requirements;
         this.baseMaps = baseMaps;
+        this.mapNames = mapNames;
         this.activeMaps = new ArrayList<>(baseMaps);
-        if (initialShuffle) this.shuffleMaps();
+        if (shuffle) this.shuffleMaps();
+        this.shuffle = shuffle;
     }
 
     public List<MapContainer> getMaps() {
         return this.activeMaps;
     }
 
+    // Map collection becomes stale if maps are loaded after startup
+    public void refresh() {
+        this.reloadMaps(); // Reconstruct basemaps
+        this.resetMapsToBase(); // Copy base to active
+        if (this.shuffle) this.shuffleMaps(); // Shuffle active if necessary
+    }
+
+    // In place shuffle of active maps
     public void shuffleMaps() {
         Collections.shuffle(this.activeMaps);
     }
 
-    public void unshuffleMaps() {
+    // Active maps are copied from base maps
+    public void resetMapsToBase() {
         this.activeMaps = new ArrayList<>(this.baseMaps);
+    }
+
+    // Reconstructs Map collection from map names. This is useful when maps are loaded after startup
+    public void reloadMaps() {
+        this.baseMaps.clear();
+
+        // If the map name list is null, add all Maps. This will only apply for the default rotation.
+        // Deserialized rotations will have a non-null (but possibly empty) collection for mapNames
+        boolean addAll = this.mapNames == null;
+
+        for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
+            if (addAll) {
+                this.baseMaps.add(mapContainer);
+                continue;
+            }
+            for (String mapName : this.mapNames) {
+                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(mapName)) {
+                    this.baseMaps.add(mapContainer);
+                }
+            }
+        }
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/RotationDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/RotationDeserializer.java
@@ -29,14 +29,17 @@ public class RotationDeserializer implements JsonDeserializer<Rotation> {
         }
 
         List<MapContainer> maps = new ArrayList<>();
+        List<String> mapNames = new ArrayList<>();
         for (JsonElement element : json.getAsJsonArray("maps")) {
+            final String mapElementName = element.getAsString();
+            mapNames.add(mapElementName);
             for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
-                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(element.getAsString())) {
+                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(mapElementName)) {
                     maps.add(mapContainer);
                 }
             }
         }
 
-        return new Rotation(name, isDefault, requirements, maps, initialShuffle);
+        return new Rotation(name, isDefault, requirements, maps, mapNames, initialShuffle);
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
@@ -1,0 +1,172 @@
+package network.warzone.tgm.map.source;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import com.google.common.collect.Iterables;
+
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PullCommand;
+import org.eclipse.jgit.api.PullResult;
+import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryCache;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.util.FS;
+
+import lombok.AllArgsConstructor;
+
+public class GitRemoteMapSource extends MapSource {
+    private final String remoteURI;
+    private String branch = null;
+
+    public GitRemoteMapSource(final String name, final File destinationDirectory, final String remoteURI) {
+        this(name, destinationDirectory, remoteURI, null);
+    }
+
+    public GitRemoteMapSource(final String name, final File destinationDirectory, final String remoteURI, final String branch) {
+        super(name, destinationDirectory);
+        this.remoteURI = remoteURI;
+        this.branch = branch;
+    }
+
+	@Override
+	public void refreshMaps() {
+        if (this.repositoryAlreadyExists()) {
+            System.out.println("Pulling changes from remote repository...");
+
+            Git localGitRepo = this.getLocalRepositoryFromDestination();
+            if (localGitRepo == null) {
+                System.out.println("Error updating remote " + this.name);
+                localGitRepo.close();
+                return;
+            }
+
+            RevCommit prePullHead = this.getRepoHead(localGitRepo);
+            if (prePullHead == null) {
+                System.out.println("Error updating remote " + this.name);
+                localGitRepo.close();
+                return;
+            }
+            try {
+                PullCommand pullCmd = localGitRepo.pull();
+                if (this.branch != null) pullCmd.setRemoteBranchName("refs/heads/" + this.branch);
+                this.chainCredentialsFromURI(pullCmd, this.remoteURI);
+                PullResult pullResult = pullCmd.call();
+                if (pullResult.isSuccessful()) {
+                    RevCommit postPullHead = this.getRepoHead(localGitRepo);
+                    int addedCommits = this.getCommitDifference(localGitRepo, prePullHead, postPullHead);
+                    System.out.println("Pulled " + addedCommits + " commits!");
+                } else {
+                    System.out.println("There was an error pulling from the remote");
+                }
+            } catch (Exception e) {
+                System.out.println("There was an error pulling from the remote");
+            }
+            localGitRepo.close();
+        } else {
+            try {
+                System.out.println("Cloning remote repository...");
+                CloneCommand cloneCommand = Git.cloneRepository()
+                    .setURI(this.remoteURI)
+                    .setDirectory(destinationDirectory)
+                    .setCloneAllBranches(false)
+                    .setCloneSubmodules(false);
+                this.chainCredentialsFromURI(cloneCommand, this.remoteURI);
+                if (this.branch != null) {
+                    cloneCommand.setBranch("refs/heads/" + branch);
+                    cloneCommand.setBranchesToClone(Collections.singleton("refs/heads/" + branch));
+                }
+                cloneCommand.call();
+            } catch (InvalidRemoteException exception) {
+                System.out.println("The specified remote was not valid, so there was an error cloning it"); 
+                return;
+            } catch (GitAPIException exception) {
+                System.out.println("Error in cloning the repository"); 
+                exception.printStackTrace();
+                return;
+            }
+            System.out.println("Successfully cloned maps from " + this.remoteURI + "!");
+        }
+	}
+
+    private void chainCredentialsFromURI(TransportCommand<?, ?> transportCommand, String remoteURI) {
+        URI parsedURI = null;
+        try {
+            parsedURI = new URI(remoteURI);
+        } catch (URISyntaxException e) {
+            return;
+        }
+        final String userCreds = parsedURI.getUserInfo();
+        if (userCreds == null) return;
+        final String[] credentials = userCreds.split(":", 2);
+        final String username = credentials[0];
+        final String password = credentials[1];
+        transportCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, password));
+    }
+
+    private RevCommit getRepoHead(Git gitRepo) {
+        RevCommit latestCommit = null;
+        try {
+            Iterable<RevCommit> revCommits = gitRepo.log().setMaxCount(1).call();
+            latestCommit = revCommits.iterator().next();
+        } catch (GitAPIException e) {
+            System.out.println("Error updating remote " + this.name);
+            return null;
+        }
+        return latestCommit;
+    }
+
+    private int getCommitDifference(Git gitRepo, RevCommit since, RevCommit until) {
+        try {
+            Iterable<RevCommit> diffCommits = gitRepo.log().addRange(since, until).call();
+            return Iterables.size(diffCommits);
+        } catch (IncorrectObjectTypeException | MissingObjectException | GitAPIException e) {
+            return 0;
+        }
+    }
+
+    private boolean repositoryAlreadyExists() {
+        return RepositoryCache.FileKey.isGitRepository(destinationDirectory, FS.DETECTED) || new File(destinationDirectory, ".git").exists();
+    }
+
+    private Git getLocalRepositoryFromDestination() {
+        Repository localRepository = null;
+        try {
+            localRepository = new FileRepository(new File(this.destinationDirectory, ".git"));
+        } catch (IOException exception) { return null; }
+        return new Git(localRepository);
+    }
+
+    public RepoData getRepoData() {
+        if (!this.repositoryAlreadyExists()) return null;
+        Git localGitRepo = this.getLocalRepositoryFromDestination();
+        if (localGitRepo == null) return null;
+        RevCommit head = this.getRepoHead(localGitRepo);
+        return new RepoData(
+            this.name,
+            head.getId().getName(),
+            head.getShortMessage(),
+            this.branch == null ? "Default Branch" : this.branch
+        );
+    }
+
+    @AllArgsConstructor
+    public static class RepoData {
+        public final String NAME;
+        public final String HEAD_ID;
+        public final String HEAD_MESSAGE;
+        public final String BRANCH;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
@@ -97,7 +97,7 @@ public class GitRemoteMapSource extends MapSource {
                 exception.printStackTrace();
                 return;
             }
-            System.out.println("Successfully cloned maps from " + this.remoteURI + "!");
+            System.out.println("Successfully cloned maps from remote '" + this.name + "'");
         }
 	}
 

--- a/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/source/GitRemoteMapSource.java
@@ -76,6 +76,10 @@ public class GitRemoteMapSource extends MapSource {
             }
             localGitRepo.close();
         } else {
+            if (this.destinationDirectory.exists() && this.destinationDirectory.listFiles().length > 0) {
+                System.out.println("Destination directory is not empty. Skipping clone.");
+                return;
+            }
             try {
                 System.out.println("Cloning remote repository...");
                 CloneCommand cloneCommand = Git.cloneRepository()

--- a/TGM/src/main/java/network/warzone/tgm/map/source/MapSource.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/source/MapSource.java
@@ -1,0 +1,23 @@
+package network.warzone.tgm.map.source;
+
+import java.io.File;
+
+public abstract class MapSource {
+    protected final String name;
+    protected final File destinationDirectory;
+
+    public MapSource(String name, File destinationDirectory) {
+        this.name = name;
+        this.destinationDirectory = destinationDirectory;
+    }
+
+    public final String getSourceName() {
+        return this.name;
+    }
+
+    public File getDestinationDirectory() {
+        return this.destinationDirectory;
+    }
+
+    public abstract void refreshMaps();
+}

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManager.java
@@ -75,13 +75,16 @@ public class MatchManager {
     }
 
     public void cycleNextMatch() {
-        matchNumber++;
-
         //find a new map to cycle to.
         MapContainer mapContainer = forcedNextMap;
         if (mapContainer == null) {
             mapContainer = mapRotation.cycle(matchNumber == 1);
+            if (mapContainer == null) {
+                System.out.println("No maps could be found in the rotation. Are there any maps?");
+                return;
+            }
         }
+        matchNumber++;
         forcedNextMap = null;
 
         //generate next match's uuid

--- a/TGM/src/main/java/network/warzone/tgm/util/AsyncHelper.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/AsyncHelper.java
@@ -1,0 +1,30 @@
+package network.warzone.tgm.util;
+
+import java.util.Collection;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nullable;
+
+/*
+ * Created by chatasma on 02/02/2021
+ */
+public class AsyncHelper {
+
+    public static void doAsync(Runnable runnable) {
+        new Thread(runnable).start();
+    }
+
+    public static void taskQueue(Collection<Runnable> tasks, @Nullable Runnable callback) {
+        taskQueueWithLock(tasks, null, callback);
+    }
+
+    public static void taskQueueWithLock(Collection<Runnable> tasks, @Nullable ReentrantLock lock, @Nullable Runnable callback) {
+        doAsync(() -> {
+            if (lock != null) lock.lock();
+            for (Runnable task : tasks) {
+                task.run();
+            }
+            if (callback != null) callback.run();
+        });
+    }
+}

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -44,6 +44,14 @@ map:
   # When the match starts, how long to take to start the match.
   # Default: 20
   start-countdown: 20
+  # Whether remote map sources should be updated on startup
+  update-remotes-on-startup: false
+  # Remote Map Sources
+  remotes:
+    official_repo:
+      branch: master
+      destination: Maps
+      uri: https://github.com/Warzone/Maps.git
   # Map repository location.
   sources:
   - Maps

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -48,7 +48,7 @@ map:
   update-remotes-on-startup: false
   # Remote Map Sources
   remotes:
-    official_repo:
+    official:
       branch: master
       destination: Maps
       uri: https://github.com/Warzone/Maps.git

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
                             <minimizeJar>true</minimizeJar>
                             <filters>
                                 <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>log4j:log4j</artifact>
                                     <includes>
                                         <include>**</include>


### PR DESCRIPTION
This will allow you to add Git repositories to pull from for Map sources.

A user can manage remote map sources using a command: `/remotes <update/view> <all/(remote name)>` (permission: `tgm.manage_remotes`). `update` will clone or update (pull commits) as appropriate. `view` will show metadata about a remote such as the latest commit on the local version and the branch it is updating from.

A user can add remote map sources through the configuration. The `remotes` and `update-remotes-on-startup` fields are optional, so this will not affect old configurations:

```yml
  # Whether remote map sources should be updated on startup
  update-remotes-on-startup: false
  # Remote Map Sources
  remotes:
    official:
      branch: master
      destination: Maps
      uri: https://github.com/Warzone/Maps.git
```

In this example, there is one remote named `official`, whose destination directory relative to the server root is `Maps`. The branch that is cloned and updated from is `master`. The config also specifies not to update remotes on startup.

The URI can also accept username/password authentication. A likely use for this are Personal Access Tokens for GitHub Repositories. For example, if I had a private repository named `PrivateMaps`, I could set the URI to `https://chatasma:PAT@github.com/chatasma/PrivateMaps.git`, where `PAT` would be replaced with the personal access token.

The PR (as needed) also prevents the server from crashing if no maps are loaded. This should make the experience for new users more smooth.

If one were to use the default configuration:

* Starting the server
* Running `/remotes update official`
* Running `/loadmaps` after update is done

would be sufficient to load in a new match, even if there were no maps previously to the server starting up.