### PR TITLE
Fix ProtocolSupport-related scoreboard truncation issue

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -161,7 +161,7 @@ public class BlitzModule extends MatchModule implements Listener {
     }
 
     private String getTeamScoreLine(MatchTeam matchTeam, int size) {
-        return "  " + ChatColor.RESET + size + ChatColor.GRAY + " Alive";
+        return ChatColor.WHITE + "  " + size + ChatColor.GRAY + " Alive";
     }
 
     private void showLives(Player player) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -75,8 +75,8 @@ public class CTFAmountController extends CTFController {
         int positionOnScoreboard = 1;
         for (MatchTeam team : teamManagerModule.getTeams()) {
             if (team.isSpectator()) continue;
-            scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-            scoreboard.add(getTeamPoints(team) + "/" + captureAmount + " captures", ++positionOnScoreboard);
+            if (positionOnScoreboard != 1) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+            scoreboard.add(ChatColor.WHITE.toString() + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
             scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
         }
         scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
@@ -101,7 +101,7 @@ public class CTFTimeController extends CTFController implements TimeLimitService
         scoreboard.removeAll(ScoreboardManagerModule.getReservedExclusions());
         int spaceCount = 1;
         int positionOnScoreboard = 1;
-        scoreboard.add("Time Left: " + ChatColor.GREEN + formattedRemainingTime, ++positionOnScoreboard);
+        scoreboard.add(ChatColor.WHITE + "Time Left: " + ChatColor.GREEN + formattedRemainingTime, ++positionOnScoreboard);
         for (MatchTeam team : teamManagerModule.getTeams()) {
             if (team.isSpectator()) continue;
             scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -53,11 +53,11 @@ public class CTWModule extends MatchModule implements Listener {
 
     @Override
     public void load(Match match) {
-        JsonObject dtmJson = match.getMapContainer().getMapInfo().getJsonObject().get("ctw").getAsJsonObject();
+        JsonObject ctwJson = match.getMapContainer().getMapInfo().getJsonObject().get("ctw").getAsJsonObject();
         this.teamManagerModule = match.getModule(TeamManagerModule.class);
         this.scoreboardManagerModule = match.getModule(ScoreboardManagerModule.class);
 
-        for (JsonElement woolElement : dtmJson.getAsJsonArray("wools")) {
+        for (JsonElement woolElement : ctwJson.getAsJsonArray("wools")) {
             JsonObject woolObject = woolElement.getAsJsonObject();
 
             String name = woolObject.get("name").getAsString();
@@ -287,16 +287,16 @@ public class CTWModule extends MatchModule implements Listener {
     private String getScoreboardString(WoolObjective woolObjective) {
         WoolStatus woolStatus = woolObjective.getStatus();
         if (woolStatus == WoolStatus.COMPLETED) {
-            return "  " + woolObjective.getColor() + SYMBOL_WOOL_COMPLETE + ChatColor.WHITE + " " + woolObjective.getName();
+            return woolObjective.getColor() + "  " + SYMBOL_WOOL_COMPLETE + ChatColor.WHITE + " " + woolObjective.getName() + " Wool";
         } else if (woolStatus == WoolStatus.TOUCHED) {
-            return "  " + woolObjective.getColor() + SYMBOL_WOOL_TOUCHED + ChatColor.WHITE + " " + woolObjective.getName();
+            return woolObjective.getColor() + "  " + SYMBOL_WOOL_TOUCHED + ChatColor.WHITE + " " + woolObjective.getName() + " Wool";
         } else {
-            return "  " + woolObjective.getColor() + SYMBOL_WOOL_INCOMPLETE + ChatColor.WHITE + " " + woolObjective.getName();
+            return woolObjective.getColor() + "  " + SYMBOL_WOOL_INCOMPLETE + ChatColor.WHITE + " " + woolObjective.getName() + " Wool";
         }
     }
 
     private String getScoreboardString(List<WoolObjective> woolObjectives) {
-        StringBuilder result = new StringBuilder();
+        StringBuilder result = new StringBuilder(ChatColor.WHITE.toString());
         for (WoolObjective woolObjective : woolObjectives) {
             WoolStatus woolStatus = woolObjective.getStatus();
             if (woolStatus == WoolStatus.COMPLETED) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -254,11 +254,11 @@ public class DTMModule extends MatchModule implements Listener {
             int percentage = monument.getHealthPercentage();
 
             if (percentage > 70) {
-                return "  " + ChatColor.GREEN.toString() + percentage + "% " + ChatColor.WHITE + monument.getName();
+                return ChatColor.GREEN + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
             } else if (percentage > 40) {
-                return "  " + ChatColor.YELLOW.toString() + percentage + "% " + ChatColor.WHITE + monument.getName();
+                return ChatColor.YELLOW + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
             } else {
-                return "  " + ChatColor.RED.toString() + percentage + "% " + ChatColor.WHITE + monument.getName();
+                return ChatColor.RED + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
             }
         } else {
             return ChatColor.WHITE + "  " + ChatColor.STRIKETHROUGH + monument.getName();

--- a/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
@@ -224,19 +224,10 @@ public class FFAModule extends MatchModule implements Listener {
                 lines.remove(0);
             }
 
-            if (this.blitzMode) {
-                if (!iterator.hasNext()) {
-                    lines.add(ChatColor.YELLOW + player + ChatColor.GRAY + ": " + ChatColor.WHITE + score);
-                } else {
-                    lines.add(this.playersTeam.getColor() + player + "" + ChatColor.GRAY + ": " + ChatColor.WHITE + score);
-                }
-            }
-            else {
-                if (!iterator.hasNext()) {
-                    lines.add(ChatColor.YELLOW + player + ChatColor.GRAY + ": " + ChatColor.RESET + score);
-                } else {
-                    lines.add(this.playersTeam.getColor() + player + ChatColor.GRAY + ": " + ChatColor.RESET + score);
-                }
+            if (!iterator.hasNext()) {
+                lines.add(ChatColor.WHITE.toString() + " " + score + " " + ChatColor.YELLOW + player);
+            } else {
+                lines.add(ChatColor.WHITE.toString() + " " + score + " " + this.playersTeam.getColor() + player);
             }
         }
         int i = 2;

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -149,7 +149,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
     public void processSecond(int elapsed) {
         int diff = (length * 60) - elapsed;
         if (diff < 0) diff = 0;
-        timeScoreboardValue = ChatColor.WHITE + "Time left: " + ChatColor.AQUA + Strings.formatTime(diff);
+        timeScoreboardValue = ChatColor.WHITE + "Time Left: " + ChatColor.AQUA + Strings.formatTime(diff) + ChatColor.WHITE;
         for (SimpleScoreboard simpleScoreboard : scoreboardManagerController.getScoreboards().values())
             refreshOnlyDynamicScoreboard(simpleScoreboard);
     }
@@ -175,7 +175,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
     private void refreshOnlyDynamicScoreboard(SimpleScoreboard board) {
         if (board == null) return;
         teamAliveScoreboardLines.forEach((id, i) -> board.add(
-                "  " + ChatColor.YELLOW + teamManager.getTeamById(id).getMembers().size() + ChatColor.WHITE + " alive", i));
+                ChatColor.WHITE + "  " + teamManager.getTeamById(id).getMembers().size() + ChatColor.GRAY + " Alive", i));
         board.add(timeScoreboardValue, timeScoreboardLine);
         board.update();
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -146,7 +146,7 @@ public class KOTHModule extends MatchModule implements Listener {
     }
 
     private String getTeamScoreLine(MatchTeam matchTeam) {
-        return pointsModule.getPoints(matchTeam) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + pointsModule.getTarget(matchTeam) + " " + matchTeam.getColor() + matchTeam.getAlias();
+        return ChatColor.WHITE.toString() + pointsModule.getPoints(matchTeam) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + pointsModule.getTarget(matchTeam) + " " + matchTeam.getColor() + matchTeam.getAlias();
     }
 
     private String getControlPointScoreboardLine(ControlPoint controlPoint) {
@@ -154,13 +154,13 @@ public class KOTHModule extends MatchModule implements Listener {
             if (controlPoint.getController() == null) {
                 return controlPoint.getProgressingTowardsTeam().getColor().toString() + controlPoint.getPercent() + "% " + ChatColor.WHITE + controlPoint.getDefinition().getName();
             } else {
-                return controlPoint.getPercent() + "% " + controlPoint.getController().getColor() + controlPoint.getDefinition().getName();
+                return ChatColor.WHITE.toString() + controlPoint.getPercent() + "% " + controlPoint.getController().getColor() + controlPoint.getDefinition().getName();
             }
         } else {
             if (controlPoint.getController() == null) {
-                return ControlPoint.SYMBOL_CP_INCOMPLETE + " " + controlPoint.getDefinition().getName();
+                return ChatColor.WHITE.toString() + ControlPoint.SYMBOL_CP_INCOMPLETE + " " + controlPoint.getDefinition().getName();
             } else {
-                return ControlPoint.SYMBOL_CP_COMPLETE + " " + controlPoint.getController().getColor() + controlPoint.getDefinition().getName();
+                return ChatColor.WHITE.toString() + ControlPoint.SYMBOL_CP_COMPLETE + " " + controlPoint.getController().getColor() + controlPoint.getDefinition().getName();
             }
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/SimpleScoreboard.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/SimpleScoreboard.java
@@ -146,6 +146,16 @@ public class SimpleScoreboard {
 
         if (text.length() > 16) {
             String prefixColor = ChatColor.getLastColors(prefix);
+            ChatColor finalColor = null;
+            if (prefixColor.length() >= 2) {
+                
+                // can be null
+                finalColor = ChatColor.getByChar(prefixColor.substring(1,2));
+            }
+            if (finalColor != null) {
+                team.setColor(finalColor);
+            }
+
             String suffix = iterator.next();
 
             if (prefix.endsWith(String.valueOf(ChatColor.COLOR_CHAR))) {
@@ -180,7 +190,7 @@ public class SimpleScoreboard {
         removed.stream().forEach((remove) -> {
             for (String s : scoreboard.getEntries()) {
                 Score score = obj.getScore(s);
-                
+
                 if (score == null) continue;
                 if (score.getScore() != remove) continue;
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 @Getter
 public class TDMModule extends MatchModule implements Listener {
-    
+
     private WeakReference<Match> match;
     private PointsModule pointsModule;
     private TeamManagerModule teamManager;
@@ -98,7 +98,7 @@ public class TDMModule extends MatchModule implements Listener {
     }
 
     private String getTeamScoreLine(MatchTeam matchTeam) {
-        return "  " + ChatColor.RESET + pointsModule.getPoints(matchTeam) + ChatColor.GRAY + "/" + pointsModule.getTarget(matchTeam) + ChatColor.WHITE + " Kills";
+        return ChatColor.WHITE + "  " + pointsModule.getPoints(matchTeam) + ChatColor.DARK_GRAY + "/" + ChatColor.GRAY + pointsModule.getTarget(matchTeam) + ChatColor.WHITE + " Kills";
     }
 
     private void incrementPoints(MatchTeam matchTeam, int amount) {


### PR DESCRIPTION
Certain aspects of how TGM generated scoreboards caused ProtocolSupport to truncate the prefix prematurely, causing the ingame scoreboard to be missing characters on many maps for players using version 1.12.2 or older versions. One of the bugs contributing this has been fixed in ProtocolSupport (so that plugin should be updated to the latest commit), but another of the issues remained. It's a side effect of how ProtocolSupport handles team colors, and overhauling it in ProtocolSupport is frankly a lot more work than simply adjusting TGM to produce its scoreboard in a way that doesn't trigger ProtocolSupport's truncation.

None of these changes will be visible on a standalone TGM server, or a TGM server paired with ViaVersion, ViaBackwards, and ViaRewind. They will only affect servers using TGM with ProtocolSupport.

As a side note, I used this opportunity to make the scoreboards more consistent across gamemodes in terms of colors used, spacing, and formatting. This specifically will show up regardless of ProtocolSupport or a lack thereof.

There are two main changes in this pull request:

- TGM now sets scoreboard teams' colors. Previously TGM did not initialize them, meaning they defaulted to `ChatColor.RESET`.
- All the scoreboard strings now have a `ChatColor` at their front. In most cases, all this required was switching the spots of the `ChatColor` and some spaces. Again, this makes no cosmetic difference to the actual strings produced.

Here is how the scoreboard looks on a standard DTW map, after these changes are implemented (and ProtocolSupport has been updated to the latest commit):
![image](https://user-images.githubusercontent.com/60436249/108620363-bd01e100-73f9-11eb-89ac-f1184831a6d2.png)
