### PR TITLE
Add support for multiple flag respawn points

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/CTFModule.java
@@ -30,6 +30,8 @@ public class CTFModule extends MatchModule implements CTFControllerSubscriber {
     private List<MatchBase> matchBases = new ArrayList<>();
     private List<MatchFlag> matchFlags = new ArrayList<>();
 
+    public static final String FULL_FLAG = "\u2691"; // ⚑
+    public static final String EMPTY_FLAG = "\u2690"; // ⚐
     public static final String RIGHT_ARROW = "\u2794"; // ➔
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -76,14 +76,16 @@ public class CTFAmountController extends CTFController {
         for (MatchTeam team : teamManagerModule.getTeams()) {
             if (team.isSpectator()) continue;
             if (positionOnScoreboard != 1) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-            scoreboard.add(ChatColor.WHITE.toString() + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
+            scoreboard.add(ChatColor.WHITE.toString() + "  " + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
             scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
         }
-        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
         boolean addedAnyFlags = false;
         for (MatchFlag flag : allFlags) {
             if (flag.getFlagHolder() == null) continue;
-            if (!addedAnyFlags) addedAnyFlags = true;
+            if (!addedAnyFlags) {
+                scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+                addedAnyFlags = true;
+            }
             MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
             ChatColor flagOwnerColor = flag.getTeam() == null ? ChatColor.WHITE : flag.getTeam().getColor();
             scoreboard.add(flagOwnerColor +

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -1,17 +1,22 @@
 package network.warzone.tgm.modules.ctf.objective;
 
+import network.warzone.tgm.TGM;
 import network.warzone.tgm.modules.ctf.CTFModule;
 import network.warzone.tgm.modules.flag.MatchFlag;
 import network.warzone.tgm.modules.scoreboard.ScoreboardInitEvent;
 import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
 import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.time.TimeModule;
+import network.warzone.tgm.modules.time.TimeSubscriber;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.potion.PotionEffect;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +26,18 @@ import static network.warzone.tgm.util.ColorConverter.format;
 /**
  * Created by yikes on 12/15/2019
  */
-public class CTFAmountController extends CTFController {
+public class CTFAmountController extends CTFController implements TimeSubscriber {
     private Map<MatchTeam, Integer> teamScores = new HashMap<>();
     private int captureAmount;
+    private boolean fancyScoreboard;
+    private boolean typedScoreboard;
+    private TimeModule timeModule;
 
     public CTFAmountController(CTFControllerSubscriber subscriber, List<MatchFlag> allFlags, int captureAmount) {
         super(subscriber, allFlags);
+        this.timeModule = TGM.get().getModule(TimeModule.class);
+        timeModule.getTimeSubscribers().add(this);
+        this.typedScoreboard = false;
         this.captureAmount = captureAmount;
     }
 
@@ -34,13 +45,11 @@ public class CTFAmountController extends CTFController {
     public void pickup(MatchFlag flag, Player stealer, List<PotionEffect> effects) {
         stealer.sendTitle(format("&aYou are carrying &f&l"+flag.getName()), format("&eBring it back to your base!"), 0, 100, 20);
         super.pickup(flag, stealer, effects);
-        updateAllScoreboards();
     }
 
     @Override
     public void drop(MatchFlag flag, Player stealer, Player attacker, List<PotionEffect> effects) {
         super.drop(flag, stealer, attacker, effects);
-        updateAllScoreboards();
     }
 
     @Override
@@ -49,8 +58,7 @@ public class CTFAmountController extends CTFController {
         MatchTeam capturingTeam = teamManagerModule.getTeam(capturer);
         int currentScore = teamScores.getOrDefault(capturingTeam, 0);
         teamScores.put(capturingTeam, ++currentScore);
-
-        updateAllScoreboards();
+        updateAllScoreboards(0);
         checkGameOver();
     }
 
@@ -60,39 +68,96 @@ public class CTFAmountController extends CTFController {
 
     @EventHandler
     public void onScoreboardInit(ScoreboardInitEvent event) {
-        updateScoreboard(event.getSimpleScoreboard());
-    }
-
-    private void updateAllScoreboards() {
-        for (SimpleScoreboard scoreboard : scoreboardManagerModule.getScoreboards().values()) {
-            updateScoreboard(scoreboard);
-        }
-    }
-
-    private void updateScoreboard(SimpleScoreboard scoreboard) {
-        scoreboard.removeAll(ScoreboardManagerModule.getReservedExclusions());
-        int spaceCount = 1;
-        int positionOnScoreboard = 1;
-        for (MatchTeam team : teamManagerModule.getTeams()) {
-            if (team.isSpectator()) continue;
-            if (positionOnScoreboard != 1) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-            scoreboard.add(ChatColor.WHITE.toString() + "  " + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
-            scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
-        }
-        boolean addedAnyFlags = false;
-        for (MatchFlag flag : allFlags) {
-            if (flag.getFlagHolder() == null) continue;
-            if (!addedAnyFlags) {
-                scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-                addedAnyFlags = true;
+        if (!typedScoreboard) {
+            typedScoreboard = true;
+            this.fancyScoreboard = true;
+            if (teamManagerModule.getTeams().size() != 3) {
+                this.fancyScoreboard = false;
             }
-            MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
-            ChatColor flagOwnerColor = flag.getTeam() == null ? ChatColor.WHITE : flag.getTeam().getColor();
-            scoreboard.add(flagOwnerColor +
-                    CTFModule.RIGHT_ARROW + " " + team.getColor() + flag.getFlagHolder().getName(), ++positionOnScoreboard);
+            if (this.fancyScoreboard) {
+                for (MatchFlag flag : allFlags) {
+                    if (flag.getCapturer() == null) {
+                        this.fancyScoreboard = false;
+                        break;
+                    }
+                }
+            }
         }
-        if (addedAnyFlags) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        updateScoreboard(event.getSimpleScoreboard(), 0);
+    }
+
+    private void updateAllScoreboards(int elapsed) {
+        for (SimpleScoreboard scoreboard : scoreboardManagerModule.getScoreboards().values()) {
+            updateScoreboard(scoreboard, elapsed);
+        }
+    }
+
+    private void updateScoreboard(SimpleScoreboard scoreboard, int elapsed) {
+        scoreboard.removeAll(ScoreboardManagerModule.getReservedExclusions());
+
+        // If the map allows for it, use a fancier PGM-style scoreboard. Otherwise default to the more basic one.
+        if (this.fancyScoreboard) {
+            int spaceCount = 1;
+            int positionOnScoreboard = 1;
+            List<MatchTeam> capturingTeams = new ArrayList<>();
+            for (MatchFlag flag : allFlags) {
+                MatchTeam team = flag.getTeam();
+                MatchTeam capturer = flag.getCapturer();
+                capturingTeams.add(capturer);
+                StringBuilder flagString = new StringBuilder(team.getColor() + " ");
+                if (flag.isWillRespawn()) {
+                    if (flag.getSecondsUntilRespawn() < 0) {
+                        flagString.append(team.getColor() + CTFModule.EMPTY_FLAG);
+                    } else {
+                        flagString.append(ChatColor.GRAY.toString() + flag.getSecondsUntilRespawn());
+                    }
+                } else if (flag.getFlagHolder() != null) {
+                    if (elapsed % 2 == 0){
+                        flagString.append(team.getColor());
+                    } else {
+                        flagString.append(ChatColor.BLACK.toString());
+                    }
+                    flagString.append(CTFModule.RIGHT_ARROW);
+                } else {
+                    flagString.append(team.getColor() + CTFModule.FULL_FLAG);
+                }
+                flagString.append(ChatColor.WHITE + " " + flag.getName());
+                scoreboard.add(flagString.toString(),++positionOnScoreboard);
+                scoreboard.add(capturer.getColor() + capturer.getAlias(), ++positionOnScoreboard);
+                scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+            }
+            for (MatchTeam team : capturingTeams) {
+                scoreboard.add(ChatColor.WHITE.toString() + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + " " + team.getColor() + team.getAlias(), ++positionOnScoreboard);
+            }
+        } else {
+            int spaceCount = 1;
+            int positionOnScoreboard = 1;
+            for (MatchTeam team : teamManagerModule.getTeams()) {
+                if (team.isSpectator()) continue;
+                if (positionOnScoreboard != 1) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+                scoreboard.add(ChatColor.WHITE.toString() + "  " + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
+                scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
+            }
+            boolean addedAnyFlags = false;
+            for (MatchFlag flag : allFlags) {
+                if (flag.getFlagHolder() == null) continue;
+                if (!addedAnyFlags) {
+                    scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+                    addedAnyFlags = true;
+                }
+                MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
+                ChatColor flagOwnerColor = flag.getTeam() == null ? ChatColor.WHITE : flag.getTeam().getColor();
+                scoreboard.add(flagOwnerColor +
+                        CTFModule.RIGHT_ARROW + " " + team.getColor() + flag.getFlagHolder().getName(), ++positionOnScoreboard);
+            }
+            if (addedAnyFlags) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+        }
         scoreboard.update();
+    }
+
+    @Override
+    public void processSecond(int elapsed) {
+        updateAllScoreboards(elapsed);
     }
 
     private void checkGameOver() {

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
@@ -57,7 +57,7 @@ public class CTFTimeController extends CTFController implements TimeLimitService
     @Override
     public void drop(MatchFlag flag, Player stealer, Player attacker, List<PotionEffect> effects) {
         super.drop(flag, stealer, attacker, effects);
-        currentFlagHolders.remove(teamManagerModule.getTeam(stealer));
+        currentFlagHolders.remove(flag.getTeamHolder());
         updateAllScoreboards(getFormattedTime());
     }
 
@@ -105,14 +105,16 @@ public class CTFTimeController extends CTFController implements TimeLimitService
         for (MatchTeam team : teamManagerModule.getTeams()) {
             if (team.isSpectator()) continue;
             scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
-            scoreboard.add(ChatColor.LIGHT_PURPLE.toString() + getTeamPoints(team) + " points", ++positionOnScoreboard);
+            scoreboard.add(ChatColor.LIGHT_PURPLE.toString() + "  " + getTeamPoints(team) + " points", ++positionOnScoreboard);
             scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
         }
-        scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
         boolean addedAnyFlags = false;
         for (MatchFlag flag : allFlags) {
             if (flag.getFlagHolder() == null) continue;
-            if (!addedAnyFlags) addedAnyFlags = true;
+            if (!addedAnyFlags) {
+                scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
+                addedAnyFlags = true;
+            }
             MatchTeam team = teamManagerModule.getTeam(flag.getFlagHolder());
             ChatColor flagOwnerColor = flag.getTeam() == null ? ChatColor.WHITE : flag.getTeam().getColor();
             scoreboard.add(flagOwnerColor +

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -72,6 +72,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
     private FlagSubscriber flagSubscriber;
     private MatchTeam team;
     private Player flagHolder;
+    private MatchTeam teamHolder;
 
     private Region protectiveRegion;
 
@@ -94,6 +95,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
 
         this.willRespawn = false;
         this.blockingRespawns = false;
+        this.teamHolder = null;
 
         this.match = new WeakReference<Match>(TGM.get().getMatchManager().getMatch());
         this.teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
@@ -230,11 +232,12 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         else if (event.getFrom().distanceSquared(location) > 1) return;
 
         this.flagHolder = event.getPlayer();
+        this.teamHolder = teamManagerModule.getTeam(this.flagHolder);
         location.getBlock().setType(Material.AIR);
 
         if(this.respawnBlock && !this.blockingRespawns){
             this.blockingRespawns = true;
-            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(teamManagerModule.getTeam(this.flagHolder),false);
+            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(this.teamHolder,false);
             Bukkit.getPluginManager().callEvent(newEvent);
         }
         flagSubscriber.pickup(this, event.getPlayer(), effects);
@@ -245,11 +248,12 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         if (match.get().getMatchStatus() != MatchStatus.MID || event.getPlayer() != flagHolder) return;
         if(this.respawnBlock && this.blockingRespawns){
             this.blockingRespawns = false;
-            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(teamManagerModule.getTeam(this.flagHolder),true);
+            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(this.teamHolder,true);
             Bukkit.getPluginManager().callEvent(newEvent);
         }
         this.flagHolder = null;
         flagSubscriber.drop(this, event.getPlayer(), null, effects);
+        this.teamHolder = null;
         this.refreshFlag();
     }
 
@@ -258,11 +262,12 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         if (match.get().getMatchStatus() != MatchStatus.MID || event.getPlayerContext().getPlayer() != flagHolder || event.getTeam().equals(event.getOldTeam())) return;
         if(this.respawnBlock && this.blockingRespawns){
             this.blockingRespawns = false;
-            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(teamManagerModule.getTeam(this.flagHolder),true);
+            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(this.teamHolder,true);
             Bukkit.getPluginManager().callEvent(newEvent);
         }
         this.flagHolder = null;
         flagSubscriber.drop(this, event.getPlayerContext().getPlayer(), null, effects);
+        this.teamHolder = null;
         this.refreshFlag();
     }
 
@@ -271,16 +276,18 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         if (match.get().getMatchStatus() != MatchStatus.MID || event.getVictim() != flagHolder) return;
         if(this.respawnBlock && this.blockingRespawns){
             this.blockingRespawns = false;
-            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(teamManagerModule.getTeam(this.flagHolder),true);
+            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(this.teamHolder,true);
             Bukkit.getPluginManager().callEvent(newEvent);
         }
         this.flagHolder = null;
         flagSubscriber.drop(this, event.getVictim(), event.getKiller(), effects);
+        this.teamHolder = null;
         this.refreshFlag();
     }
 
     public void unload() {
         flagHolder = null;
+        teamHolder = null;
 
         // No task was scheduled if json specifies instant flag respawns
         if(this.respawnTime > 0){
@@ -293,11 +300,12 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
     public void redeem(Player player) {
         if(this.respawnBlock && this.blockingRespawns){
             this.blockingRespawns = false;
-            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(teamManagerModule.getTeam(this.flagHolder),true);
+            FlagRespawnBlockEvent newEvent = new FlagRespawnBlockEvent(this.teamHolder,true);
             Bukkit.getPluginManager().callEvent(newEvent);
         }
         this.flagHolder = null;
         flagSubscriber.capture(this, player, effects);
+        this.teamHolder = null;
         this.refreshFlag();
     }
 


### PR DESCRIPTION
Flags now have an optional `respawn-locations` attribute which is an array of points. If specified, one of them is chosen randomly every time a flag respawns. If omitted, the flag always spawns at its original location.

Syntax:
```json
"respawn-locations": [
	"3.5,15,-445.5",
	"3.5,20,-475.5",
	"3.5,20,-415.5"
]
```
I also fixed a bug related to players switching teams or quitting the game while carrying a flag, and slightly changed the scoreboard formatting to look better.