### PR TITLE
Full case-insensitive team finding

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
@@ -24,6 +24,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 @ModuleData(load = ModuleLoadTime.EARLIEST) @Getter @Setter
@@ -147,15 +148,16 @@ public class TeamManagerModule extends MatchModule implements Listener {
             return found;
         }
 
+        String lowered = input.toLowerCase();
         if (found == null) {
             for (MatchTeam matchTeam : teams) {
-                if (matchTeam.getId().startsWith(input)) {
+                if (matchTeam.getId().toLowerCase().startsWith(lowered)) {
                     return matchTeam;
                 }
             }
 
             for (MatchTeam matchTeam : teams) {
-                if (matchTeam.getAlias().startsWith(input)) {
+                if (matchTeam.getAlias().toLowerCase().startsWith(lowered)) {
                     return matchTeam;
                 }
             }

--- a/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/TeamManagerModule.java
@@ -24,7 +24,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Random;
 
 @ModuleData(load = ModuleLoadTime.EARLIEST) @Getter @Setter


### PR DESCRIPTION
TGM can find a team by its complete ID or name in a case-insensitive manner, however, it cannot do the same for finding teams by its alias/ID's starting characters. This PR enhances the starting character check to also work in a case-insensitive manner.