### PR TITLE
Reduce Square Root Usages

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -227,7 +227,7 @@ public class SpectatorModule extends MatchModule implements Listener {
                 player.setVelocity(player.getVelocity().setY(4.0)); // Get out of that void!
                 player.setFlying(true);
             }
-        } else if (event.getFrom().distance(event.getTo()) > 0) {
+        } else if (event.getFrom().distanceSquared(event.getTo()) > 0) {
             lastMovement.put(player.getUniqueId(), System.currentTimeMillis());
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
@@ -29,7 +29,7 @@ public class CylinderRegion implements Region {
 
     @Override
     public boolean contains(Location location) {
-        return Math.sqrt(NumberConversions.square(base.getX() - location.getX()) + NumberConversions.square(base.getZ() - location.getZ())) <= radius &&
+        return NumberConversions.square(base.getX() - location.getX()) + NumberConversions.square(base.getZ() - location.getZ()) <= radius * radius &&
                 location.getY() >= base.getY() &&
                 location.getY() <= base.getY() + height;
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
@@ -51,7 +51,7 @@ public class HemisphereRegion implements Region {
     }
     @Override
     public boolean contains(Location location) {
-        return hemisphereFace.hemisphereDirectionEvaluation.contains(focalPoint, location) && focalPoint.distance(location) <= radius;
+        return hemisphereFace.hemisphereDirectionEvaluation.contains(focalPoint, location) && focalPoint.distanceSquared(location) <= radius * radius;
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
@@ -30,7 +30,7 @@ public class SphereRegion implements Region {
 
     @Override
     public boolean contains(Location location) {
-        return center.distance(location) <= radius;
+        return center.distanceSquared(location) <= radius * radius;
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/util/Players.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/Players.java
@@ -101,7 +101,7 @@ public class Players {
             org.bukkit.Location loc = location(player);
             org.bukkit.Location loc1 = location(p1);
             org.bukkit.Location loc2 = location(p2);
-            return Integer.compare((int) loc.distance(loc1), (int) loc.distance(loc2));
+            return Integer.compare((int) loc.distanceSquared(loc1), (int) loc.distanceSquared(loc2));
         });
     }
 


### PR DESCRIPTION
These usages of the square root function are completely unnecessary, as we only need to know which of two distances is bigger, not the actual value.

Not tested, because it's not worth it for a simple math problem like this. Someone obviously should still review this.

There is still another square root usage in the getLevelProgress function, which is called 10 times per second for every online player