### PR TITLE
Rework DTM Scoreboard and fix Team Alias Issue

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -15,6 +15,7 @@ import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamChangeEvent;
 import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.modules.team.TeamUpdateEvent;
 import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.player.event.PlayerJoinTeamAttemptEvent;
 import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
@@ -150,6 +151,16 @@ public class BlitzModule extends MatchModule implements Listener {
         }
     }
 
+    public void updateScoreboardAliasLine(MatchTeam matchTeam) {
+        if (!teamScoreboardLines.containsKey(matchTeam)) return;
+        for (SimpleScoreboard simpleScoreboard : TGM.get().getModule(ScoreboardManagerModule.class).getScoreboards().values()) {
+            int line = teamScoreboardLines.get(matchTeam);
+            simpleScoreboard.remove(line + 1);
+            simpleScoreboard.add(matchTeam.getColor() + matchTeam.getAlias(), line + 1);
+            simpleScoreboard.update();
+        }
+    }
+
     public void updateScoreboardTeamLine(MatchTeam matchTeam, int size) {
         if (!teamScoreboardLines.containsKey(matchTeam)) return;
         for (SimpleScoreboard simpleScoreboard : TGM.get().getModule(ScoreboardManagerModule.class).getScoreboards().values()) {
@@ -162,6 +173,12 @@ public class BlitzModule extends MatchModule implements Listener {
 
     private String getTeamScoreLine(MatchTeam matchTeam, int size) {
         return ChatColor.WHITE + "  " + size + ChatColor.GRAY + " Alive";
+    }
+
+    @EventHandler
+    public void onTeamUpdate(TeamUpdateEvent event) {
+        MatchTeam team = event.getMatchTeam();
+        if (!team.isSpectator()) updateScoreboardAliasLine(team);
     }
 
     private void showLives(Player player) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -168,7 +168,7 @@ public class DTMModule extends MatchModule implements Listener {
             if(matchTeam.isSpectator()) continue;
 
             for (Monument monument : this.monuments) {
-                if (monument.getOwners().contains(matchTeam)) {
+                if (!monument.getOwners().contains(matchTeam)) {
                     if (this.monumentScoreboardLines.containsKey(monument)) {
                         this.monumentScoreboardLines.get(monument).add(i);
                     } else {
@@ -250,19 +250,14 @@ public class DTMModule extends MatchModule implements Listener {
     }
 
     private String getScoreboardString(Monument monument) {
-        if (monument.isAlive()) {
-            int percentage = monument.getHealthPercentage();
-
-            if (percentage > 70) {
-                return ChatColor.GREEN + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
-            } else if (percentage > 40) {
-                return ChatColor.YELLOW + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
-            } else {
-                return ChatColor.RED + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
-            }
-        } else {
-            return ChatColor.WHITE + "  " + ChatColor.STRIKETHROUGH + monument.getName();
+        int percentage = 100 - monument.getHealthPercentage();
+        ChatColor healthColor = ChatColor.YELLOW;
+        if (percentage <= 0) {
+            healthColor = ChatColor.RED;
+        } else if (percentage >= 100) {
+            healthColor = ChatColor.GREEN;
         }
+        return healthColor + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
     }
 
     private List<Monument> getAliveMonuments(MatchTeam matchTeam) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -17,6 +17,7 @@ import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
 import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamChangeEvent;
+import network.warzone.tgm.modules.team.TeamUpdateEvent;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.modules.time.TimeSubscriber;
@@ -165,6 +166,14 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
         return this.humans;
     }
 
+    private void refreshScoreboardAlias(MatchTeam matchTeam) {
+        for (SimpleScoreboard simpleScoreboard : TGM.get().getModule(ScoreboardManagerModule.class).getScoreboards().values()) {
+            int line = teamAliveScoreboardLines.get(matchTeam.getId());
+            simpleScoreboard.remove(line + 1);
+            simpleScoreboard.add(matchTeam.getColor() + matchTeam.getAlias(), line + 1);
+            simpleScoreboard.update();
+        }
+    }
 
     private void refreshScoreboard(SimpleScoreboard board) {
         if (board == null) return;
@@ -222,6 +231,12 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
         timeScoreboardValue = ChatColor.WHITE + "Time: " + ChatColor.AQUA + "0:00";
         teamScoreboardLines.put(positionOnScoreboard, StringUtils.repeat(" ", spaceCount));
         defaultScoreboardLoaded = true;
+    }
+
+    @EventHandler
+    public void onTeamUpdate(TeamUpdateEvent event) {
+        MatchTeam team = event.getMatchTeam();
+        if (!team.isSpectator()) refreshScoreboardAlias(team);
     }
 
     @EventHandler

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -16,6 +16,7 @@ import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
 import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.modules.team.TeamUpdateEvent;
 import network.warzone.tgm.modules.time.TimeModule;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -165,6 +165,12 @@ public class KOTHModule extends MatchModule implements Listener {
         }
     }
 
+    @EventHandler
+    public void onTeamUpdate(TeamUpdateEvent event) {
+        MatchTeam team = event.getMatchTeam();
+        if (!team.isSpectator()) updateScoreboardTeamLine(team);
+    }
+
     @Override
     public void disable() {
         for (ControlPoint controlPoint : controlPoints) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
@@ -11,6 +11,7 @@ import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
 import network.warzone.tgm.modules.scoreboard.SimpleScoreboard;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.modules.team.TeamUpdateEvent;
 import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
 import org.bukkit.ChatColor;
@@ -106,6 +107,15 @@ public class TDMModule extends MatchModule implements Listener {
         updateScoreboardTeamLine(matchTeam);
     }
 
+    private void updateScoreboardAliasLine(MatchTeam matchTeam) {
+        for (SimpleScoreboard simpleScoreboard : TGM.get().getModule(ScoreboardManagerModule.class).getScoreboards().values()) {
+            int line = teamScoreboardLines.get(matchTeam.getId());
+            simpleScoreboard.remove(line + 1);
+            simpleScoreboard.add(matchTeam.getColor() + matchTeam.getAlias(), line + 1);
+            simpleScoreboard.update();
+        }
+    }
+
     private void updateScoreboardTeamLine(MatchTeam matchTeam) {
         for (SimpleScoreboard simpleScoreboard : TGM.get().getModule(ScoreboardManagerModule.class).getScoreboards().values()) {
             int line = teamScoreboardLines.get(matchTeam.getId());
@@ -113,6 +123,12 @@ public class TDMModule extends MatchModule implements Listener {
             simpleScoreboard.add(getTeamScoreLine(matchTeam), line);
             simpleScoreboard.update();
         }
+    }
+
+    @EventHandler
+    public void onTeamUpdate(TeamUpdateEvent event) {
+        MatchTeam team = event.getMatchTeam();
+        if (!team.isSpectator()) updateScoreboardAliasLine(team);
     }
 
     @EventHandler


### PR DESCRIPTION
The current DTM scoreboard is confusing because it displays monuments from the defenders' perspective, as opposed to other gamemodes where objectives are displayed from the attackers' perspective. I have fixed this, and also made the formatting a bit nicer. 

I have also fixed a bug which is that four gamemodes (KoTH, Blitz, Infection, TDM) did not update their scoreboards when a team's alias was changed.