### PR TITLE
Add Block Interact Filter

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -66,6 +66,7 @@ public class FilterManagerModule extends MatchModule {
         else if ("usebow".equals(type))         filterTypes.add(UseBowFilterType.parse(match, jsonObject));
         else if ("useshear".equals(type))       filterTypes.add(UseShearFilterType.parse(match, jsonObject));
         else if ("leave".equals(type))          filterTypes.add(LeaveFilterType.parse(match, jsonObject));
+        else if ("blockinteract".equals(type))  filterTypes.add(BlockInteractFilterType.parse(match, jsonObject));
         else if ("blockexplode".equals(type))   filterTypes.add(BlockExplodeFilterType.parse(match, jsonObject));
         else if ("blockplace".equals(type))     filterTypes.add(BlockPlaceFilterType.parse(match, jsonObject));
         else if ("blockbreak".equals(type))     filterTypes.add(BlockBreakFilterType.parse(match, jsonObject));

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
@@ -24,6 +24,7 @@ import java.util.List;
  */
 @AllArgsConstructor @Getter
 public class BlockExplodeFilterType implements FilterType, Listener {
+
     private final List<Region> regions;
     private final FilterEvaluator evaluator;
     private final boolean inverted;

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
@@ -204,5 +204,4 @@ public class BuildFilterType implements FilterType, Listener {
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new BuildFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }
-
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 @AllArgsConstructor @Getter
 public class EnterFilterType implements FilterType, Listener {
+
     private final List<MatchTeam> teams;
     private final List<Region> regions;
     private final FilterEvaluator evaluator;

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
@@ -70,5 +70,4 @@ public class LeaveFilterType implements FilterType, Listener {
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new LeaveFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }
-
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
@@ -32,7 +32,7 @@ public class UseShearFilterType implements FilterType, Listener {
     private final List<Region> regions;
     private final FilterEvaluator evaluator;
     private final String message;
-    private final  boolean inverted;
+    private final boolean inverted;
 
     @EventHandler
     public void onShear(PlayerShearEntityEvent e) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/VoidBuildFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/VoidBuildFilterType.java
@@ -93,5 +93,4 @@ public class VoidBuildFilterType implements FilterType, Listener {
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new VoidBuildFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }
-
 }


### PR DESCRIPTION
- Cancels any interactions with blocks inside a region
- Includes block placement and breaking as well
- Reformats other filter types (I had to)

This is useful to prevent the owner of a wool room to open their own wool/supply chests. Turf Wars is an example of a map where that is possible. Another solution would be to just build the wool room in a way which makes it impossible for the owner of the room to reach the chests, but that could be bypassed by breaking a block around the chest and using the short time until the block reappears to open the chest.