### PR TITLE
Modify spectator inventory layout for convenience

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -69,9 +69,9 @@ public class SpectatorModule extends MatchModule implements Listener {
     public SpectatorModule() {
         this.teamSelectionMenu = new PublicMenu(ChatColor.UNDERLINE + "Team Selection", 9);
 
-        compassItem = ItemFactory.createItem(Material.COMPASS, ChatColor.YELLOW + "Teleport Tool");
-        teamSelectionItem = ItemFactory.createItem(Material.NETHER_STAR, ChatColor.YELLOW + "Team Selection");
-        teleportMenuItem = ItemFactory.createItem(Material.CLOCK, ChatColor.YELLOW + "Player Teleport");
+        compassItem = ItemFactory.createItem(Material.COMPASS, ChatColor.BLUE.toString() + ChatColor.BOLD.toString() + "Teleport Tool");
+        teamSelectionItem = ItemFactory.createItem(Material.LEATHER_HELMET, ChatColor.GREEN.toString() + ChatColor.BOLD.toString() + "Team Selection");
+        teleportMenuItem = ItemFactory.createItem(Material.CLOCK, ChatColor.AQUA.toString() + ChatColor.BOLD.toString() + "Player Teleport");
 
         leatherHelmet = new ItemStack(Material.LEATHER_HELMET);
         LeatherArmorMeta leatherHelmetMeta = (LeatherArmorMeta) leatherHelmet.getItemMeta();
@@ -132,12 +132,12 @@ public class SpectatorModule extends MatchModule implements Listener {
         playerContext.getPlayer().setCollidable(false);
 
         playerContext.getPlayer().getInventory().setHelmet(leatherHelmet);
-        playerContext.getPlayer().getInventory().setItem(2, compassItem);
-        playerContext.getPlayer().getInventory().setItem(4, teamSelectionItem);
-        playerContext.getPlayer().getInventory().setItem(6, teleportMenuItem);
-        // Inventory slot 8 is reserved for the kitEditorItem in KitLoaderModule
+        playerContext.getPlayer().getInventory().setItem(0, compassItem);
+        playerContext.getPlayer().getInventory().setItem(2, teamSelectionItem);
+        playerContext.getPlayer().getInventory().setItem(8, teleportMenuItem);
+        // Inventory slot 6 is reserved for the kitEditorItem in KitLoaderModule
 
-        playerContext.getPlayer().getInventory().setHeldItemSlot(4);
+        playerContext.getPlayer().getInventory().setHeldItemSlot(2);
     }
 
     private void updateTeamMenuItem(MatchTeam matchTeam, int i) {
@@ -315,7 +315,7 @@ public class SpectatorModule extends MatchModule implements Listener {
             event.setCancelled(true);
         }
     }
-    
+
     @EventHandler
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         if (isSpectating(event.getPlayer())) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/KitEditorModule.java
@@ -33,7 +33,7 @@ public class KitEditorModule extends MatchModule implements Listener {
     @Getter private HashMap<UUID, KitEditorMenu> editorMenus;
 
     public KitEditorModule() {
-        kitEditorItem = ItemFactory.createItem(Material.CHEST, ChatColor.YELLOW + "Kit Editor");
+        kitEditorItem = ItemFactory.createItem(Material.CHEST, ChatColor.YELLOW.toString() + ChatColor.BOLD.toString() + "Custom Layouts");
     }
 
     public void load() {
@@ -50,7 +50,7 @@ public class KitEditorModule extends MatchModule implements Listener {
         for (MatchTeam matchTeam : TGM.get().getModule(TeamManagerModule.class).getTeams()) {
             if (!matchTeam.isSpectator()) continue;
             for (PlayerContext player : matchTeam.getMembers()) {
-                player.getPlayer().getInventory().clear(8);
+                player.getPlayer().getInventory().clear(6);
             }
         }
 
@@ -65,7 +65,7 @@ public class KitEditorModule extends MatchModule implements Listener {
         for (MatchTeam matchTeam : TGM.get().getModule(TeamManagerModule.class).getTeams()) {
             if (!matchTeam.isSpectator()) continue;
             for (PlayerContext player : matchTeam.getMembers()) {
-                player.getPlayer().getInventory().setItem(8, kitEditorItem);
+                player.getPlayer().getInventory().setItem(6, kitEditorItem);
             }
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/menu/KitEditorMenu.java
@@ -181,7 +181,7 @@ public class KitEditorMenu implements Listener {
         if (!event.getInventory().equals(inventory)) return;
 
         Bukkit.getScheduler().runTask(TGM.get(), () -> {
-            event.getPlayer().getInventory().clear(0);
+            event.getPlayer().getInventory().clear(1);
         });
     }
 }


### PR DESCRIPTION
- The compass is now in slot 0.
- The team joiner (nether star) has been replaced with a leather helmet and moved to slot 2.
- The kit editor has been moved to slot 6.
- The player teleporter has been moved to slot 8.
- All of these items' names have been bolded for better visibility.