### PR TITLE
Prettify DTM Scoreboard For Single Monuments

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -258,6 +258,12 @@ public class DTMModule extends MatchModule implements Listener {
         } else if (percentage >= 100) {
             healthColor = ChatColor.GREEN;
         }
+
+        if (monument.getMaxHealth() == 1) {
+            if (percentage <= 0) healthColor = ChatColor.WHITE;
+            return ChatColor.GRAY + "  - " + healthColor + monument.getName();
+        }
+
         return healthColor + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -41,6 +41,9 @@ import static org.bukkit.SoundCategory.AMBIENT;
 @Getter
 public class DTMModule extends MatchModule implements Listener {
 
+    private static final String SYMBOL_MONUMENT_INCOMPLETE = "\u2715"; // ✕
+    private static final String SYMBOL_MONUMENT_COMPLETE = "\u2714"; // ✔
+
     @Getter private final List<Monument> monuments = new ArrayList<>();
     private final HashMap<Monument, List<Integer>> monumentScoreboardLines = new HashMap<>();
     private final HashMap<String, Integer> teamScoreboardLines = new HashMap<>();
@@ -259,9 +262,11 @@ public class DTMModule extends MatchModule implements Listener {
             healthColor = ChatColor.GREEN;
         }
 
-        if (monument.getMaxHealth() == 1) {
-            if (percentage <= 0) healthColor = ChatColor.WHITE;
-            return ChatColor.GRAY + "  - " + healthColor + monument.getName();
+        if (monument.getMaxHealth() == 1 || percentage >= 100) {
+            String symbol = ChatColor.GREEN + SYMBOL_MONUMENT_COMPLETE;
+            if (percentage <= 0) symbol = ChatColor.RED + SYMBOL_MONUMENT_INCOMPLETE;
+
+            return ChatColor.GRAY + "  " + symbol + " " + ChatColor.WHITE + monument.getName();
         }
 
         return healthColor + "  " + percentage + "% " + ChatColor.WHITE + monument.getName();


### PR DESCRIPTION
- If the max health of a monument is 1, which applies on maps with a single obsidian block, like Quintus, Sector Six etc., the scoreboard won't show percentages, but instead this:

![image](https://user-images.githubusercontent.com/7355350/113507275-b793cc80-9549-11eb-83a3-78a2863fff65.png)
Two of the five monuments are broken

![image](https://user-images.githubusercontent.com/7355350/113507285-c7abac00-9549-11eb-8233-eeff4e8e9258.png)
All five monuments are broken

![image](https://user-images.githubusercontent.com/7355350/113507292-d09c7d80-9549-11eb-9f57-cb269841033f.png)
Nothing changes if the max health is bigger than 1