### PR TITLE
Resolve minor CTF issues

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFController.java
@@ -59,7 +59,7 @@ public abstract class CTFController implements FlagSubscriber, Listener, TimeLim
         for (PotionEffect effect : effects) {
             stealer.removePotionEffect(effect.getType());
         }
-        MatchTeam team = teamManagerModule.getTeam(stealer);
+        MatchTeam team = flag.getTeamHolder();
         if (team == null) team = teamManagerModule.getSpectators();
         if (team == null) return;
         if (flag.getTeam() == null) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -124,6 +124,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
         // No task necessary if json specifies instant flag respawns
         if(this.respawnTime > 0){
             task = Bukkit.getScheduler().runTaskTimer(TGM.get(), () -> {
+                if (match.get().getMatchStatus() != MatchStatus.MID) return;
                 secondsUntilRespawn = ((this.timeDropped + this.respawnTime) - now()) / (long)1000;
                 if (this.willRespawn && secondsUntilRespawn <= 0) {
                     this.willRespawn = false;


### PR DESCRIPTION
Fixes #747 - Flags can no longer respawn if the match is over.

Fixes #748 - If a flag holder leaves the match, the chat message saying they dropped the flag will use their previous team color.