### PR TITLE
JSON Scoreboard Consistency

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -132,12 +132,13 @@ public class BlitzModule extends MatchModule implements Listener {
         simpleScoreboard.setTitle(ChatColor.AQUA + "Blitz");
 
         int i = 2;
-        for (MatchTeam matchTeam : teams) {
+        for (int j = teams.size() - 1; j >= 0; j--) {
+            MatchTeam matchTeam = teams.get(j);
             if (matchTeam.isSpectator()) continue;
             simpleScoreboard.add(matchTeam.getColor() + getTeamScoreLine(matchTeam, getAlivePlayers(matchTeam).size()), i);
             teamScoreboardLines.put(matchTeam, i++);
             simpleScoreboard.add(matchTeam.getColor() + matchTeam.getAlias(), i++);
-            if (teams.indexOf(matchTeam) < teams.size() - 1) {
+            if (j > 1) {
                 simpleScoreboard.add(matchTeam.getColor() + " ", i++);
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFAmountController.java
@@ -102,7 +102,8 @@ public class CTFAmountController extends CTFController implements TimeSubscriber
             int spaceCount = 1;
             int positionOnScoreboard = 1;
             List<MatchTeam> capturingTeams = new ArrayList<>();
-            for (MatchFlag flag : allFlags) {
+            for (int k = allFlags.size() - 1; k >= 0; k--) {
+                MatchFlag flag = allFlags.get(k);
                 MatchTeam team = flag.getTeam();
                 MatchTeam capturer = flag.getCapturer();
                 capturingTeams.add(capturer);
@@ -128,20 +129,23 @@ public class CTFAmountController extends CTFController implements TimeSubscriber
                 scoreboard.add(capturer.getColor() + capturer.getAlias(), ++positionOnScoreboard);
                 scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
             }
-            for (MatchTeam team : capturingTeams) {
+            for (int j = capturingTeams.size() - 1; j >= 0; j--) {
+                MatchTeam team = capturingTeams.get(j);
                 scoreboard.add(ChatColor.WHITE.toString() + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + " " + team.getColor() + team.getAlias(), ++positionOnScoreboard);
             }
         } else {
             int spaceCount = 1;
             int positionOnScoreboard = 1;
-            for (MatchTeam team : teamManagerModule.getTeams()) {
+            for (int j = teamManagerModule.getTeams().size() - 1; j >= 0; j--) {
+                MatchTeam team = teamManagerModule.getTeams().get(j);
                 if (team.isSpectator()) continue;
                 if (positionOnScoreboard != 1) scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
                 scoreboard.add(ChatColor.WHITE.toString() + "  " + getTeamPoints(team) + ChatColor.DARK_GRAY.toString() + "/" + ChatColor.GRAY.toString() + captureAmount + ChatColor.WHITE.toString() + " Captures", ++positionOnScoreboard);
                 scoreboard.add(team.getColor() + team.getAlias(), ++positionOnScoreboard);
             }
             boolean addedAnyFlags = false;
-            for (MatchFlag flag : allFlags) {
+            for (int k = allFlags.size() - 1; k >= 0; k--) {
+                MatchFlag flag = allFlags.get(k);
                 if (flag.getFlagHolder() == null) continue;
                 if (!addedAnyFlags) {
                     scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctf/objective/CTFTimeController.java
@@ -103,7 +103,8 @@ public class CTFTimeController extends CTFController implements TimeSubscriber {
         int spaceCount = 1;
         int positionOnScoreboard = 1;
         scoreboard.add(ChatColor.WHITE + "Time Left: " + ChatColor.GREEN + formattedRemainingTime, ++positionOnScoreboard);
-        for (MatchTeam team : teamManagerModule.getTeams()) {
+        for (int j = teamManagerModule.getTeams().size() - 1; j >= 0; j--) {
+            MatchTeam team = teamManagerModule.getTeams().get(j);
             if (team.isSpectator()) continue;
             scoreboard.add(StringUtils.repeat(" ", ++spaceCount), ++positionOnScoreboard);
             scoreboard.add(ChatColor.LIGHT_PURPLE.toString() + "  " + getTeamPoints(team) + " points", ++positionOnScoreboard);

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -190,10 +190,12 @@ public class CTWModule extends MatchModule implements Listener {
         int spaceCount = 1;
         int i = 2;
         if (!compactLayout) {
-            for (MatchTeam matchTeam : teams) {
+            for (int j = teams.size() - 1; j >= 0; j--) {
+                MatchTeam matchTeam = teams.get(j);
                 if (matchTeam.isSpectator()) continue;
 
-                for (WoolObjective woolObjective : wools) {
+                for (int k = wools.size() - 1; k >= 0; k--) {
+                    WoolObjective woolObjective = wools.get(k);
                     if (woolObjective.getOwner().equals(matchTeam)) {
                         if (woolScoreboardLines.containsKey(woolObjective)) {
                             woolScoreboardLines.get(woolObjective).add(i);
@@ -209,16 +211,20 @@ public class CTWModule extends MatchModule implements Listener {
                 simpleScoreboard.add(getTeamScoreboardString(matchTeam), i);
                 teamScoreboardLines.put(matchTeam.getId(), i++);
 
-                if (teams.indexOf(matchTeam) < teams.size() - 1) {
+                if (j > 1) {
                     simpleScoreboard.add(StringUtils.repeat(" ", spaceCount++), i++);
                 }
             }
         } else {
-            for (MatchTeam matchTeam : teams) {
+            for (int j = teams.size() - 1; j >= 0; j--) {
+                MatchTeam matchTeam = teams.get(j);
+
                 if (matchTeam.isSpectator()) continue;
 
                 List<WoolObjective> wools = getTeamWoolObjectives(matchTeam);
-                for (WoolObjective woolObjective : wools) {
+                for (int k = wools.size() - 1; k >= 0; k--) {
+                    WoolObjective woolObjective = wools.get(k);
+
                     if (woolObjective.getOwner().equals(matchTeam)) {
                         if (woolScoreboardLines.containsKey(woolObjective)) {
                             woolScoreboardLines.get(woolObjective).add(i);
@@ -233,7 +239,7 @@ public class CTWModule extends MatchModule implements Listener {
                 simpleScoreboard.add(getTeamScoreboardString(matchTeam), i);
                 teamScoreboardLines.put(matchTeam.getId(), i++);
 
-                if (teams.indexOf(matchTeam) < teams.size() - 1) {
+                if (j > 1) {
                     simpleScoreboard.add(StringUtils.repeat(" ", spaceCount++), i++);
                 }
             }

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -165,10 +165,12 @@ public class DTMModule extends MatchModule implements Listener {
         simpleScoreboard.setTitle(ChatColor.AQUA + "Destroy the Monument");
         int spaceCount = 1;
         int i = 2;
-        for (MatchTeam matchTeam : teams) {
+        for (int j = teams.size() - 1; j >= 0; j--) {
+            MatchTeam matchTeam = teams.get(j);
             if(matchTeam.isSpectator()) continue;
 
-            for (Monument monument : this.monuments) {
+            for (int k = this.monuments.size() - 1; k >= 0; k--) {
+                Monument monument = this.monuments.get(k);
                 if (!monument.getOwners().contains(matchTeam)) {
                     if (this.monumentScoreboardLines.containsKey(monument)) {
                         this.monumentScoreboardLines.get(monument).add(i);
@@ -184,7 +186,7 @@ public class DTMModule extends MatchModule implements Listener {
             simpleScoreboard.add(getTeamScoreboardString(matchTeam), i);
             this.teamScoreboardLines.put(matchTeam.getId(), i++);
 
-            if (teams.indexOf(matchTeam) < teams.size() - 1) {
+            if (j > 1) {
                 simpleScoreboard.add(StringUtils.repeat(" ", spaceCount++), i++);
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -219,7 +219,8 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
         teamAliveScoreboardLines.clear();
         int positionOnScoreboard = 1;
         int spaceCount = 1;
-        for (MatchTeam team : teamManager.getTeams()) {
+        for (int j = teamManager.getTeams().size() - 1; j >= 0; j--) {
+            MatchTeam team = teamManager.getTeams().get(j);
             if (team.isSpectator()) continue;
             teamScoreboardLines.put(positionOnScoreboard, StringUtils.repeat(" ", spaceCount++));
             positionOnScoreboard++;

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -128,21 +128,24 @@ public class KOTHModule extends MatchModule implements Listener {
         List<MatchTeam> teams = TGM.get().getModule(TeamManagerModule.class).getTeams();
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
         simpleScoreboard.setTitle(ChatColor.AQUA + "King of the Hill");
-        int j = 2;
-        for (ControlPoint controlPoint : controlPoints) {
-            controlPointScoreboardLines.put(controlPoint.getDefinition(), j);
-            simpleScoreboard.add(getControlPointScoreboardLine(controlPoint), j);
-            j++;
+        int i = 2;
+        for (int k = controlPoints.size() - 1; k >= 0; k--) {
+            ControlPoint controlPoint = controlPoints.get(k);
+            controlPointScoreboardLines.put(controlPoint.getDefinition(), i);
+            simpleScoreboard.add(getControlPointScoreboardLine(controlPoint), i);
+            i++;
         }
-        simpleScoreboard.add(" ", j);
+        simpleScoreboard.add(" ", i);
 
-        for (MatchTeam matchTeam : teams) {
+        for (int j = teams.size() - 1; j >= 0; j--) {
+            MatchTeam matchTeam = teams.get(j);
+
             if (matchTeam.isSpectator()) continue;
 
-            j++;
+            i++;
 
-            simpleScoreboard.add(getTeamScoreLine(matchTeam), j);
-            teamScoreboardLines.put(matchTeam, j);
+            simpleScoreboard.add(getTeamScoreLine(matchTeam), i);
+            teamScoreboardLines.put(matchTeam, i);
         }
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
@@ -87,12 +87,13 @@ public class TDMModule extends MatchModule implements Listener {
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
         simpleScoreboard.setTitle(ChatColor.AQUA + "Team Deathmatch");
         int i = 2;
-        for (MatchTeam matchTeam : teams) {
+        for (int j = teams.size() - 1; j >= 0; j--) {
+            MatchTeam matchTeam = teams.get(j);
             if (matchTeam.isSpectator()) continue;
             simpleScoreboard.add(matchTeam.getColor() + getTeamScoreLine(matchTeam), i);
             teamScoreboardLines.put(matchTeam.getId(), i++);
             simpleScoreboard.add(matchTeam.getColor() + matchTeam.getAlias(), i++);
-            if (teams.indexOf(matchTeam) < teams.size() - 1) {
+            if (j > 1) {
                 simpleScoreboard.add(matchTeam.getColor() + " ", i++);
             }
         }


### PR DESCRIPTION
Due to the way that scoreboards work (from bottom to top), the JSON order of monuments/wools/hills and even teams were always reversed on the scoreboard.

This commit simply reverses the objective and team iterations, to make the scoreboard consistent with the order in the JSON.

Tested.