### PR TITLE
Fix Generators NPE

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/generator/GeneratorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/generator/GeneratorModule.java
@@ -77,7 +77,9 @@ public class GeneratorModule extends MatchModule implements TaskedModule {
     @Override
     public void disable() {
         for (Generator generator : generators) {
-            generator.getGeneratorUpgrader().unload();
+            if (generator.getGeneratorUpgrader() != null) {
+                generator.getGeneratorUpgrader().unload();
+            }
         }
         matchStarted = false;
         generators = null;


### PR DESCRIPTION
If the generatorUpgrader variable is null, it will cause the disable method to throw a NPE and the match can't end.