### PR TITLE
Add Random Region Locations

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/AbsoluteRegionSpawnPoint.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/AbsoluteRegionSpawnPoint.java
@@ -1,0 +1,23 @@
+package network.warzone.tgm.map.spawnpoints;
+
+import network.warzone.tgm.modules.region.Region;
+import org.bukkit.Location;
+
+public class AbsoluteRegionSpawnPoint extends RegionSpawnPoint {
+    private final float yaw;
+    private final float pitch;
+
+    public AbsoluteRegionSpawnPoint(Region region, float yaw, float pitch) {
+        this.region = region;
+        this.yaw = yaw;
+        this.pitch = pitch;
+    }
+
+    @Override
+    public Location getLocation() {
+        Location location = region.getRandomLocation();
+        location.setYaw(yaw);
+        location.setPitch(pitch);
+        return location;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/LocationSpawnPoint.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/LocationSpawnPoint.java
@@ -1,0 +1,14 @@
+package network.warzone.tgm.map.spawnpoints;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.Location;
+
+@AllArgsConstructor
+public class LocationSpawnPoint implements SpawnPoint {
+    private final Location point;
+
+    @Override
+    public Location getLocation() {
+        return point;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/RegionSpawnPoint.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/RegionSpawnPoint.java
@@ -1,0 +1,7 @@
+package network.warzone.tgm.map.spawnpoints;
+
+import network.warzone.tgm.modules.region.Region;
+
+public abstract class RegionSpawnPoint implements SpawnPoint {
+    protected Region region;
+}

--- a/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/RelativeRegionSpawnPoint.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/RelativeRegionSpawnPoint.java
@@ -1,0 +1,32 @@
+package network.warzone.tgm.map.spawnpoints;
+
+import network.warzone.tgm.modules.region.Region;
+import org.bukkit.Location;
+
+public class RelativeRegionSpawnPoint extends RegionSpawnPoint {
+    private final Location faceCoordinates;
+
+    public RelativeRegionSpawnPoint(Region region, Location faceCoordinates) {
+        this.region = region;
+        this.faceCoordinates = faceCoordinates;
+    }
+
+    @Override
+    public Location getLocation() {
+        Location location = region.getRandomLocation();
+
+        // Trigonometry to determine yaw and pitch
+        double dX = faceCoordinates.getX() - location.getX();
+        double dY = faceCoordinates.getY() - location.getY() - 1.62; // Subtract eye height
+        double dZ = faceCoordinates.getZ() - location.getZ();
+
+        double distance = Math.sqrt(dX * dX + dZ * dZ);
+        float yaw = (float) (Math.atan2(dZ, dX) * 180 / Math.PI) - 90.0F;
+        float pitch = (float) -(Math.atan2(dY, distance) * 180 / Math.PI);
+
+        location.setYaw(yaw);
+        location.setPitch(pitch);
+
+        return location;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/SpawnPoint.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/spawnpoints/SpawnPoint.java
@@ -1,0 +1,7 @@
+package network.warzone.tgm.map.spawnpoints;
+
+import org.bukkit.Location;
+
+public interface SpawnPoint {
+    Location getLocation();
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
@@ -3,7 +3,7 @@ package network.warzone.tgm.modules;
 import lombok.Getter;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
-import network.warzone.tgm.map.SpawnPoint;
+import network.warzone.tgm.map.spawnpoints.SpawnPoint;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchManager;
 import network.warzone.tgm.match.MatchModule;

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointLoaderModule.java
@@ -43,7 +43,7 @@ public class SpawnPointLoaderModule extends MatchModule {
             if (spawnJson.has("coords")) {
                 spawnPoint = new LocationSpawnPoint(Parser.convertLocation(match.getWorld(), spawnJson.get("coords")));
             } else if (spawnJson.has("region")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, spawnJson.getAsJsonObject("region"));
+                Region region = match.getModule(RegionManagerModule.class).getRegion(match, spawnJson.get("region"));
 
                 if (spawnJson.has("face-coordinates")) {
                     spawnPoint = new RelativeRegionSpawnPoint(region, Parser.convertLocation(match.getWorld(), spawnJson.get("face-coordinates")));

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointLoaderModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointLoaderModule.java
@@ -3,13 +3,17 @@ package network.warzone.tgm.modules;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import network.warzone.tgm.map.SpawnPoint;
+import network.warzone.tgm.map.spawnpoints.AbsoluteRegionSpawnPoint;
+import network.warzone.tgm.map.spawnpoints.LocationSpawnPoint;
+import network.warzone.tgm.map.spawnpoints.RelativeRegionSpawnPoint;
+import network.warzone.tgm.map.spawnpoints.SpawnPoint;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Parser;
-import org.bukkit.Location;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,14 +39,25 @@ public class SpawnPointLoaderModule extends MatchModule {
                 }
             }
 
-            Location location;
+            SpawnPoint spawnPoint = null;
             if (spawnJson.has("coords")) {
-                location = Parser.convertLocation(match.getWorld(), spawnJson.get("coords"));
-            } else {
-                location = Parser.convertLocation(match.getWorld(), spawnJson);
+                spawnPoint = new LocationSpawnPoint(Parser.convertLocation(match.getWorld(), spawnJson.get("coords")));
+            } else if (spawnJson.has("region")) {
+                Region region = match.getModule(RegionManagerModule.class).getRegion(match, spawnJson.getAsJsonObject("region"));
+
+                if (spawnJson.has("face-coordinates")) {
+                    spawnPoint = new RelativeRegionSpawnPoint(region, Parser.convertLocation(match.getWorld(), spawnJson.get("face-coordinates")));
+                } else {
+                    float yaw = 0; float pitch = 0;
+                    if (spawnJson.has("yaw")) yaw = spawnJson.get("yaw").getAsFloat();
+                    if (spawnJson.has("pitch")) pitch = spawnJson.get("pitch").getAsFloat();
+
+                    spawnPoint = new AbsoluteRegionSpawnPoint(region, yaw, pitch);
+                }
             }
-            SpawnPoint spawnPoint = new SpawnPoint(location);
+
             for (MatchTeam matchTeam : teams) {
+                if (spawnPoint == null) continue;
                 matchTeam.addSpawnPoint(spawnPoint);
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/CuboidRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/CuboidRegion.java
@@ -9,10 +9,12 @@ import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 @Getter
 public class CuboidRegion implements Region {
     private final World world;
+    private final Random random;
 
     private double minX;
     private double minY;
@@ -27,6 +29,8 @@ public class CuboidRegion implements Region {
     public CuboidRegion(Location min, Location max) {
         Preconditions.checkArgument(min.getWorld() == max.getWorld(), "region location worlds must match");
         this.world = min.getWorld();
+        this.random = new Random();
+
         minX = Math.min(min.getX(), max.getX());
         maxX = Math.max(min.getX(), max.getX());
 
@@ -64,6 +68,14 @@ public class CuboidRegion implements Region {
     public Location getCenter() {
         Vector v = getMin().toVector().getMidpoint(getMax().toVector());
         return new Location(world, v.getX(), v.getY(), v.getZ());
+    }
+
+    @Override
+    public Location getRandomLocation() {
+        double x = getMinX() + (getMaxX() - getMinX()) * random.nextDouble();
+        double y = getMinY() + (getMaxY() - getMinY()) * random.nextDouble();
+        double z = getMinZ() + (getMaxZ() - getMinZ()) * random.nextDouble();
+        return new Location(world, x, y, z);
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
@@ -18,6 +18,8 @@ public class CylinderRegion implements Region {
     private final Location min;
     private final Location max;
 
+    private final CuboidRegion bound;
+
     public CylinderRegion(Location base, double radius, double height) {
         this.base = base;
         this.radius = radius;
@@ -25,6 +27,8 @@ public class CylinderRegion implements Region {
 
         this.min = new Location(base.getWorld(), base.getX() - radius, base.getY(), base.getZ() - radius);
         this.max = new Location(base.getWorld(), base.getX() + radius, base.getY() + height, base.getZ() + radius);
+
+        this.bound = new CuboidRegion(this.min, this.max);
     }
 
     @Override
@@ -42,6 +46,17 @@ public class CylinderRegion implements Region {
     @Override
     public Location getCenter() {
         return base;
+    }
+
+    @Override
+    public Location getRandomLocation() {
+        Location location = bound.getRandomLocation();
+
+        while (!contains(location)) {
+            location = bound.getRandomLocation();
+        }
+
+        return location;
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
@@ -17,6 +17,8 @@ public class HemisphereRegion implements Region {
     private final Location max;
     private HemisphereFace hemisphereFace;
 
+    private final CuboidRegion bound;
+
     public HemisphereRegion(Location focalPoint, double radius, HemisphereFace hemisphereFace) {
        this.focalPoint = focalPoint;
        this.radius = radius;
@@ -48,6 +50,8 @@ public class HemisphereRegion implements Region {
                this.max = new Location(focalPoint.getWorld(), focalPoint.getX() + radius, focalPoint.getY() + radius, focalPoint.getZ() - radius);
                break;
        }
+
+       this.bound = new CuboidRegion(this.min, this.max);
     }
     @Override
     public boolean contains(Location location) {
@@ -62,6 +66,17 @@ public class HemisphereRegion implements Region {
     @Override
     public Location getCenter() {
         return this.focalPoint;
+    }
+
+    @Override
+    public Location getRandomLocation() {
+        Location location = bound.getRandomLocation();
+
+        while (!contains(location)) {
+            location = bound.getRandomLocation();
+        }
+
+        return location;
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/MetaRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/MetaRegion.java
@@ -10,14 +10,15 @@ import org.bukkit.block.Block;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Created by Jorge on 10/09/2019
  */
 @Getter
 public class MetaRegion implements Region {
-
     private List<Region> regions = new ArrayList<>();
+    private Random random;
 
     private World world;
     private int minX;
@@ -29,12 +30,14 @@ public class MetaRegion implements Region {
     private Location min;
     private Location max;
 
+
     public MetaRegion(JsonArray jsonArray) {
         for (JsonElement element : jsonArray) {
             this.regions.add(TGM.get().getModule(RegionManagerModule.class).getRegion(TGM.get().getMatchManager().getMatch(), element));
         }
         this.world = TGM.get().getMatchManager().getMatch().getWorld();
         calculateMinMax();
+        random = new Random();
     }
 
     @Override
@@ -53,6 +56,11 @@ public class MetaRegion implements Region {
     @Override
     public Location getCenter() {
         return new Location(world, (minX + maxX) / 2D, (minY + maxY) / 2D, (minZ + maxZ) / 2D);
+    }
+
+    @Override
+    public Location getRandomLocation() { // Every region gets the same chance, regardless of its volume
+        return getRegions().get(random.nextInt(getRegions().size())).getRandomLocation();
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/Region.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/Region.java
@@ -12,6 +12,8 @@ public interface Region {
 
     Location getCenter();
 
+    Location getRandomLocation();
+
     List<Block> getBlocks();
 
     Location getMin();

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
@@ -20,12 +20,16 @@ public class SphereRegion implements Region {
     private final Location min;
     private final Location max;
 
+    private final CuboidRegion bound;
+
     public SphereRegion(Location center, double radius) {
         this.center = center;
         this.radius = radius;
 
         this.min = new Location(center.getWorld(), center.getX() - radius, center.getY() - radius, center.getZ() - radius);
         this.max = new Location(center.getWorld(), center.getX() + radius, center.getY() + radius, center.getZ() + radius);
+
+        this.bound = new CuboidRegion(this.min, this.max);
     }
 
     @Override
@@ -38,9 +42,21 @@ public class SphereRegion implements Region {
         return contains(block.getLocation());
     }
 
+
     @Override
     public Location getCenter() {
         return this.center;
+    }
+
+    @Override
+    public Location getRandomLocation() {
+        Location location = bound.getRandomLocation();
+
+        while (!contains(location)) {
+            location = bound.getRandomLocation();
+        }
+
+        return location;
     }
 
     @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/team/MatchTeam.java
@@ -3,7 +3,7 @@ package network.warzone.tgm.modules.team;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import network.warzone.tgm.map.SpawnPoint;
+import network.warzone.tgm.map.spawnpoints.SpawnPoint;
 import network.warzone.tgm.modules.kit.Kit;
 import network.warzone.tgm.modules.team.event.TeamUpdateAliasEvent;
 import network.warzone.tgm.modules.team.event.TeamUpdateMaximumEvent;


### PR DESCRIPTION
- Adds a getRandomLocation() method for every region type. It is done in the most efficient way possible for cylinders, spheres and hemispheres: Cuboid bounds are set around the region and random locations within that cuboid are generated until one such location is also contained within the original region type. Meta regions will generate a random number to select a region in their list. A random location within that region is then returned.

- Adds more JSON flexibility for spawn points. A spawn point can now be defined in the old way using a single location via "coords", or in a new way by passing a "region". The region can be locally defined or referenced with its ID, similar to how it's done in CTW/DTM objective regions.

Two types of region spawn points can be used: Absolute and relative ones. A relative region spawn point will make the player face whatever coordinates are given in the "face-coordinates" variable. An absolute region spawn point will by default use yaws and pitches of 0, or whatever is given in the corresponding variables.

```json
{   
    "teams": ["red"],
    "region": {
        "id": "red-spawn-1", "type": "cuboid",
        "min": "255, 50, 223", "max": "310, 50, 223"
    },
    "yaw": 90,
    "pitch": 30
}
```
**Local region registration. Uses absolute yaws and pitches**

```json
{   
    "teams": ["blue"],
    "region": "blue-spawn-1",
    "face-coordinates": "257, 53, 276"
}
```
**Reference to a global region. Uses relative yaws and pitches**

The pre-existing spawn points which only use single locations are 100% compatible with this commit.

Closes https://github.com/Warzone/TGM/issues/245
Closes https://github.com/Warzone/TGM/issues/622