### PR TITLE
Add XP Rewards and Stat Tracking in CTW

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -118,6 +118,14 @@ public class CTWModule extends MatchModule implements Listener {
                     if (getIncompleteWools(matchTeam).isEmpty()) {
                         TGM.get().getMatchManager().endMatch(matchTeam);
                     }
+
+                    if (TGM.get().getApiManager().isStatsDisabled()) return;
+
+                    PlayerContext playerContext = TGM.get().getPlayerManager().getPlayerContext(player);
+                    playerContext.getUserProfile().addWoolDestroy();
+                    Bukkit.getPluginManager().callEvent(new PlayerXPEvent(playerContext, UserProfile.XP_PER_WOOL_BREAK, playerContext.getUserProfile().getXP() - UserProfile.XP_PER_WOOL_BREAK, playerContext.getUserProfile().getXP()));
+                    Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().destroyWool(new DestroyWoolRequest(player.getUniqueId())));
+
                 }
 
                  @Override


### PR DESCRIPTION
- Rewards XP when capturing wool (10xp)
- Adds wool captures in the wool destroy stat on the api.

Not too sure why this wasn't already a thing- it's already implemented in DTM and DTW, so I don't see a reason why it shouldn't be in CTW?