### PR TITLE
JSON Rotation Order Consistency

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/MapLoaderImpl.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapLoaderImpl.java
@@ -34,9 +34,7 @@ public class MapLoaderImpl implements MapLoader {
                     }
                 } else {
                     //recursively loop through directories
-                    for (MapContainer mapContainer : loadMaps(child)) {
-                        maps.add(mapContainer);
-                    }
+                    maps.addAll(loadMaps(child));
                 }
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
@@ -12,7 +12,7 @@ public class Rotation {
     @Getter private final boolean isDefault;
     @Getter private final RotationRequirement requirements;
     private final List<String> mapNames;
-    private List<MapContainer> baseMaps;
+    private final List<MapContainer> baseMaps;
     private List<MapContainer> activeMaps;
     private final boolean shuffle;
 

--- a/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/Rotation.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import network.warzone.tgm.TGM;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,16 +11,16 @@ public class Rotation {
     @Getter private final String name;
     @Getter private final boolean isDefault;
     @Getter private final RotationRequirement requirements;
-    private final Collection<String> mapNames;
+    private final List<String> mapNames;
     private List<MapContainer> baseMaps;
     private List<MapContainer> activeMaps;
     private final boolean shuffle;
 
-    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, Collection<String> mapNames) {
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, List<String> mapNames) {
         this(name, isDefault, requirements, baseMaps, mapNames, false);
     }
 
-    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, Collection<String> mapNames, final boolean shuffle) {
+    public Rotation(final String name, final boolean isDefault, final RotationRequirement requirements, List<MapContainer> baseMaps, List<String> mapNames, final boolean shuffle) {
         this.name = name;
         this.isDefault = isDefault;
         this.requirements = requirements;
@@ -59,16 +58,15 @@ public class Rotation {
 
         // If the map name list is null, add all Maps. This will only apply for the default rotation.
         // Deserialized rotations will have a non-null (but possibly empty) collection for mapNames
-        boolean addAll = this.mapNames == null;
 
-        for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
-            if (addAll) {
-                this.baseMaps.add(mapContainer);
-                continue;
-            }
+        if (this.mapNames == null) {
+            this.baseMaps.addAll(TGM.get().getMatchManager().getMapLibrary().getMaps());
+        } else {
             for (String mapName : this.mapNames) {
-                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(mapName)) {
-                    this.baseMaps.add(mapContainer);
+                for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
+                    if (mapContainer.getMapInfo().getName().equalsIgnoreCase(mapName)) {
+                        this.baseMaps.add(mapContainer);
+                    }
                 }
             }
         }


### PR DESCRIPTION
In the reloadMaps() method, the JSON rotation map order previously lost its order. It would always use the order in which the maps have been loaded in the map library. I fixed it by first iterating through the map names instead of the map library.

This obviously only applies to rotations which are not shuffled.

Tested.

Edit: This does not fix the issue where the first map in the rotation is being played twice. (Only happens on server startups, as far as I can remember)