### PR TITLE
Fix NullChunkGenerator

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/map/NullChunkGenerator.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/NullChunkGenerator.java
@@ -2,7 +2,6 @@ package network.warzone.tgm.map;
 
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.block.Biome;
 import org.bukkit.generator.ChunkGenerator;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,15 +13,7 @@ import java.util.Random;
 public class NullChunkGenerator extends ChunkGenerator {
     @Override
     public @NotNull ChunkData generateChunkData(@NotNull World world, @NotNull Random random, int x, int z, @NotNull BiomeGrid biomeGrid) {
-        ChunkData data = createChunkData(world);
-        for (int i = 0; i < 16; i++) {
-            for (int j = 0; j < 256; j++) {
-                for (int k = 0; k < 16; k++) {
-                    biomeGrid.setBiome(i, j, k, Biome.PLAINS);
-                }
-            }
-        }
-        return data;
+        return createChunkData(world);
     }
 
     @Override


### PR DESCRIPTION
Creates void chunks. The BiomeGrid#setBiome is not needed at all

Tested.