### PR TITLE
Prettify Inventory Preview

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/InventoryUtil.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 
+import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +30,7 @@ import java.util.Collections;
  * Created by Jorge on 10/16/2019
  */
 public class InventoryUtil {
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0");
 
     public static Inventory clone(Inventory i, String title) {
         Inventory inventory;
@@ -94,7 +96,7 @@ public class InventoryUtil {
         return ItemFactory.createItem(Material.APPLE, ChatColor.RED + "Player health", Arrays.asList(
                 ChatColor.GRAY + "Health: " + ChatColor.WHITE + ((int) player.getHealth()) + " / " + ((int) player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()),
                 ChatColor.GRAY + "Food: " + ChatColor.WHITE + player.getFoodLevel(),
-                ChatColor.GRAY + "Saturation: " + ChatColor.WHITE + player.getSaturation()
+                ChatColor.GRAY + "Saturation: " + ChatColor.WHITE + DECIMAL_FORMAT.format(player.getSaturation())
         ));
     }
 


### PR DESCRIPTION
Sometimes, saturation levels behave weirdly, as shown in the first screenshot. This is simply fixed by using a decimal format which limits the number to one decimal, as shown in the second screenshot.

![image](https://user-images.githubusercontent.com/7355350/120084266-09328080-c0cf-11eb-8426-31bbae8cabdd.png)
![image](https://user-images.githubusercontent.com/7355350/120084303-56aeed80-c0cf-11eb-90b7-43c0509c8bc7.png)
