### PR TITLE
Fix Capture Points

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -125,7 +125,11 @@ public class KOTHModule extends MatchModule implements Listener {
             }
         }
 
-        return highestCapturePointIndex == controlPointIndex;
+        if (!reversed) {
+            return highestCapturePointIndex >= controlPointIndex;
+        } else {
+            return highestCapturePointIndex <= controlPointIndex;
+        }
     }
 
     private MatchTeam getMostCapturesTeam() {


### PR DESCRIPTION
This fixes a bug where a team can't restore one of their controlled point's progress to 100% once an enemy manages to get it below 100%, without fully neutralizing the point or even capturing it.

Tested.