### PR TITLE
Fix KOTH Hill Coloring, Scoreboard

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/controlpoint/ControlPointDefinition.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/controlpoint/ControlPointDefinition.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import network.warzone.tgm.modules.portal.Portal;
 import network.warzone.tgm.modules.region.Region;
 import network.warzone.tgm.modules.team.MatchTeam;
+import org.bukkit.ChatColor;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,6 +17,7 @@ public class ControlPointDefinition {
     private final MatchTeam initialOwner;
     private final int maxProgress;
     private final int pointsPerTick;
+    private final ChatColor neutralColor;
 
     private final HashMap<MatchTeam, Portal> portals;
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHControlPointService.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHControlPointService.java
@@ -38,7 +38,7 @@ public class KOTHControlPointService implements ControlPointService {
     @Override
     public void captured(MatchTeam matchTeam) {
         Bukkit.broadcastMessage(matchTeam.getColor() + ChatColor.BOLD.toString() + matchTeam.getAlias() + ChatColor.WHITE +
-                " took control of " + ChatColor.AQUA + ChatColor.BOLD.toString() + definition.getName());
+                " took control of " + ChatColor.AQUA + ChatColor.BOLD + definition.getName());
 
         for (MatchTeam team : match.getModule(TeamManagerModule.class).getTeams()) {
             for (PlayerContext playerContext : team.getMembers()) {
@@ -72,9 +72,8 @@ public class KOTHControlPointService implements ControlPointService {
 
     @Override
     public void lost(MatchTeam matchTeam) {
-        kothModule.updateScoreboardControlPointLine(definition);
         Bukkit.broadcastMessage(matchTeam.getColor() + ChatColor.BOLD.toString() + matchTeam.getAlias() + ChatColor.WHITE +
-                " lost control of " + ChatColor.AQUA + ChatColor.BOLD.toString() + definition.getName());
+                " lost control of " + ChatColor.AQUA + ChatColor.BOLD + definition.getName());
 
         if (kothModule.getKothObjective() == KOTHObjective.CAPTURES) {
             if (definition.getPortals() != null && definition.getPortals().containsKey(matchTeam)) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -21,6 +21,7 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.team.event.TeamUpdateAliasEvent;
 import network.warzone.tgm.modules.time.TimeModule;
+import network.warzone.tgm.util.Strings;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -34,6 +35,8 @@ import java.util.stream.Collectors;
 @Getter
 public class KOTHModule extends MatchModule implements Listener {
 
+    public static ChatColor GLOBAL_NEUTRAL_COLOR = ChatColor.WHITE;
+
     private final List<ControlPoint> controlPoints = new ArrayList<>();
     private PointsModule pointsModule;
     private KOTHObjective kothObjective = KOTHObjective.POINTS;
@@ -45,6 +48,10 @@ public class KOTHModule extends MatchModule implements Listener {
     @Override
     public void load(Match match) {
         JsonObject kothJson = match.getMapContainer().getMapInfo().getJsonObject().get("koth").getAsJsonObject();
+
+        if (kothJson.has("neutral-color")) {
+            GLOBAL_NEUTRAL_COLOR = ChatColor.valueOf(Strings.getTechnicalName(kothJson.get("neutral-color").getAsString()));
+        }
 
         for (JsonElement capturePointElement : kothJson.getAsJsonArray("hills")) {
             JsonObject capturePointJson = capturePointElement.getAsJsonObject();
@@ -64,6 +71,11 @@ public class KOTHModule extends MatchModule implements Listener {
             final int pointsPerHold = swap;
             final String name = capturePointJson.get("name").getAsString();
 
+            ChatColor neutralColor = GLOBAL_NEUTRAL_COLOR;
+            if (capturePointJson.has("neutral-color")) {
+                neutralColor = ChatColor.valueOf(Strings.getTechnicalName(capturePointJson.get("neutral-color").getAsString()));
+            }
+
             HashMap<MatchTeam, Portal> portals = null;
             if (capturePointJson.has("portals")) {
                 portals = new HashMap<>();
@@ -76,7 +88,7 @@ public class KOTHModule extends MatchModule implements Listener {
                 }
             }
 
-            ControlPointDefinition definition = new ControlPointDefinition(name, owner, timeToCap, pointsPerHold, portals);
+            ControlPointDefinition definition = new ControlPointDefinition(name, owner, timeToCap, pointsPerHold, neutralColor, portals);
             ControlPoint controlPoint = new ControlPoint(this, definition, region, new KOTHControlPointService(this, match, definition));
 
             controlPoints.add(controlPoint);


### PR DESCRIPTION
This commit fixes two small visual bugs within the KOTH/CP gametype and moves a supported feature from the map blocks themselves to the JSON map configuration.

- A small scoreboard visual bug was fixed where once hill control is lost and progress is at 0%, the scoreboard line would still color the hill name with the previous controller's team color. This happened because the scoreboard lines were updated before controller was set to null.
- Hills without initial owners will all by default be colored white. This change had to be made because otherwise, a visual bug was possible: If a hill which never was captured before is advanced to let's say 30%, the blocks will be colored accordingly. 30% of the hill will be the capturing team's color, with the remaining 70% not being affected at all/remaining neutral. If the other team manages to stop the original team from advancing its progress before it reaches 100% and starts to reverse it, the hill's blocks would end up not updating their colors correctly. The solution I used was to simply "move" this feature of letting the map authors define the neutral hill color from the original hill block colors of the map to the JSON. All hills will be colored once the KOTHModule is loaded. The `koth` object accepts a new key, named `neutral-color` which accepts a chat color as input. This will be the default neutral hill color for the map. If not defined in the JSON, the default hill color is hardcoded to white. Hills can override the default neutral hill color by passing a chat color to the same `neutral-color` within a hill object.
- Small String cast redundancies were removed.

Tested.