### PR TITLE
Preperations for block containment checking conversion

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/base/MatchBase.java
@@ -53,14 +53,14 @@ public class MatchBase implements Listener {
     // Filters are wack. Do not allow build or break in the base region
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
-        if (!baseRegion.contains(event.getBlock().getLocation())) return;
+        if (!baseRegion.contains(event.getBlock())) return;
         event.getPlayer().sendMessage(ChatColor.RED + "You cannot break near a capture base!");
         event.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockPlace(BlockPlaceEvent event) {
-        if (!baseRegion.contains(event.getBlock().getLocation())) return;
+        if (!baseRegion.contains(event.getBlock())) return;
         event.getPlayer().sendMessage(ChatColor.RED + "You cannot build near a capture base!");
         event.setCancelled(true);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
@@ -16,6 +16,7 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Strings;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -40,7 +41,7 @@ public class BlockBreakFilterType implements FilterType, Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockPlaceEvent(BlockBreakEvent event) {
         for (Region region : regions) {
-            if (contains(region, event.getBlock().getLocation())) {
+            if (contains(region, event.getBlock())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -55,8 +56,8 @@ public class BlockBreakFilterType implements FilterType, Listener {
         }
     }
 
-    private boolean contains(Region region, Location location) {
-        return (!inverted && region.contains(location)) || (inverted && !region.contains(location));
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     private boolean canBreak(BlockBreakEvent event, FilterResult filterResult) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
@@ -35,7 +35,7 @@ public class BlockExplodeFilterType implements FilterType, Listener {
         for (Block block : event.blockList()) {
             for (Region region : regions) {
                 FilterResult filterResult = evaluator.evaluate();
-                if (filterResult == FilterResult.DENY && contains(region, block.getLocation()) &&
+                if (filterResult == FilterResult.DENY && contains(region, block) &&
                         !cancelledBlocks.contains(block)) {
                     cancelledBlocks.add(block);
                 }
@@ -47,8 +47,8 @@ public class BlockExplodeFilterType implements FilterType, Listener {
         }
     }
 
-    private boolean contains(Region region, Location location) {
-        return (!inverted && region.contains(location)) || (inverted && !region.contains(location));
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     public static BlockExplodeFilterType parse(Match match, JsonObject jsonObject) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockInteractFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockInteractFilterType.java
@@ -17,6 +17,7 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Strings;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -41,7 +42,7 @@ public class BlockInteractFilterType implements FilterType, Listener {
         if (event.getClickedBlock() == null) return;
 
         for (Region region : regions) {
-            if (contains(region, event.getClickedBlock().getLocation())) {
+            if (contains(region, event.getClickedBlock())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -56,8 +57,8 @@ public class BlockInteractFilterType implements FilterType, Listener {
         }
     }
 
-    private boolean contains(Region region, Location location) {
-        return (!inverted && region.contains(location)) || (inverted && !region.contains(location));
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     @SuppressWarnings("ConstantConditions") // null check already passed

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
@@ -16,6 +16,7 @@ import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Strings;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -40,7 +41,7 @@ public class BlockPlaceFilterType implements FilterType, Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockPlaceEvent(BlockPlaceEvent event) {
         for (Region region : regions) {
-            if (contains(region, event.getBlockPlaced().getLocation())) {
+            if (contains(region, event.getBlockPlaced())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -55,8 +56,8 @@ public class BlockPlaceFilterType implements FilterType, Listener {
         }
     }
 
-    private boolean contains(Region region, Location location) {
-        return (!inverted && region.contains(location)) || (inverted && !region.contains(location));
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     private boolean canPlace(BlockPlaceEvent event, FilterResult filterResult) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
@@ -42,7 +42,7 @@ public class BuildFilterType implements FilterType, Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
         for (Region region : regions) {
-            if (contains(region, event.getBlockPlaced().getLocation())) {
+            if (contains(region, event.getBlockPlaced())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -61,7 +61,7 @@ public class BuildFilterType implements FilterType, Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         for (Region region : regions) {
-            if (contains(region, event.getBlock().getLocation())) {
+            if (contains(region, event.getBlock())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -79,7 +79,7 @@ public class BuildFilterType implements FilterType, Listener {
 
     @EventHandler
     public void onPlayerClickItemFram(PlayerInteractEntityEvent event) {
-        if (!event.isCancelled() && event.getRightClicked() != null && event.getRightClicked() instanceof ItemFrame) {
+        if (!event.isCancelled() && event.getRightClicked() instanceof ItemFrame) {
             for (Region region : regions) {
                 if (contains(region, event.getRightClicked().getLocation())) {
                     for (MatchTeam matchTeam : teams) {
@@ -182,6 +182,10 @@ public class BuildFilterType implements FilterType, Listener {
                 }
             }
         }
+    }
+
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     private boolean contains(Region region, Location location) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/VoidBuildFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/VoidBuildFilterType.java
@@ -47,7 +47,7 @@ public class VoidBuildFilterType implements FilterType, Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
         for (Region region : regions) {
-            if (contains(region, event.getBlockPlaced().getLocation())) {
+            if (contains(region, event.getBlockPlaced())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -63,8 +63,8 @@ public class VoidBuildFilterType implements FilterType, Listener {
         }
     }
 
-    private boolean contains(Region region, Location location) {
-        return (!inverted && region.contains(location)) || (inverted && !region.contains(location));
+    private boolean contains(Region region, Block block) {
+        return (!inverted && region.contains(block)) || (inverted && !region.contains(block));
     }
 
     private boolean isAboveVoid(Block placed) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/flag/MatchFlag.java
@@ -141,7 +141,7 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
 
         TGM.registerEvents(this);
 
-        if (bannerType.contains("WALL")) {
+        if (bannerType.contains("WALL")) { // TODO: Adjust this region when switching from block positions to coordinates
             this.protectiveRegion = new CuboidRegion(
                     location.clone().subtract(1, 2, 1),
                     location.clone().add(1, 1, 1)
@@ -159,14 +159,14 @@ public class MatchFlag extends PlayerRedeemable implements Listener {
     // Filters are wack. Do not allow build or break in the base region
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
-        if (!protectiveRegion.contains(event.getBlock().getLocation())) return;
+        if (!protectiveRegion.contains(event.getBlock())) return;
         event.getPlayer().sendMessage(ChatColor.RED + "You cannot break near a flag area!");
         event.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockPlace(BlockPlaceEvent event) {
-        if (!protectiveRegion.contains(event.getBlock().getLocation())) return;
+        if (!protectiveRegion.contains(event.getBlock())) return;
         event.getPlayer().sendMessage(ChatColor.RED + "You cannot build near a flag area!");
         event.setCancelled(true);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/monument/Monument.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/monument/Monument.java
@@ -39,7 +39,7 @@ public class Monument implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             if (materials == null || materials.contains(event.getBlock().getType())) {
                 if (!canDamage(event.getPlayer())) {
                     event.getPlayer().sendMessage(ChatColor.RED + "You cannot damage a monument you own.");
@@ -54,7 +54,7 @@ public class Monument implements Listener {
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockBreakHighest(BlockBreakEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             if (materials == null || materials.contains(event.getBlock().getType())) {
                 if (canDamage(event.getPlayer())) {
                     Match match = this.match.get();
@@ -83,7 +83,7 @@ public class Monument implements Listener {
 
     @EventHandler
     public void onBlockBurn(BlockBurnEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             if (materials == null || materials.contains(event.getBlock().getType())) {
                 event.setCancelled(true);
             }
@@ -92,20 +92,20 @@ public class Monument implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onBlockIgniteEvent(BlockIgniteEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             event.setCancelled(true);
         }
     }
     @EventHandler(priority = EventPriority.HIGH)
     public void onPistonRetract(BlockPistonRetractEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             event.setCancelled(true);
         }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onPistonExtend(BlockPistonExtendEvent event) {
-        if (region.contains(event.getBlock().getLocation())) {
+        if (region.contains(event.getBlock())) {
             event.setCancelled(true);
         }
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/CylinderRegion.java
@@ -64,7 +64,7 @@ public class CylinderRegion implements Region {
         List<Block> results = new ArrayList<>();
         CuboidRegion bound = new CuboidRegion(getMin(), getMax());
         for (Block block : bound.getBlocks()) {
-            if (contains(new Location(TGM.get().getMatchManager().getMatch().getWorld(), block.getX(), block.getY(), block.getZ()))) results.add(block);
+            if (contains(block)) results.add(block);
         }
         return results;
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/HemisphereRegion.java
@@ -84,7 +84,7 @@ public class HemisphereRegion implements Region {
         List<Block> results = new ArrayList<>();
         CuboidRegion bound = new CuboidRegion(this.min, this.max);
         for (Block block : bound.getBlocks()) {
-            if (contains(new Location(focalPoint.getWorld(), block.getX(), block.getY(), block.getZ()))) results.add(block);
+            if (contains(block)) results.add(block);
         }
         return results;
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/region/SphereRegion.java
@@ -64,7 +64,7 @@ public class SphereRegion implements Region {
         List<Block> results = new ArrayList<>();
         CuboidRegion bound = new CuboidRegion(getMin(), getMax());
         for (Block block : bound.getBlocks()) {
-            if (contains(new Location(TGM.get().getMatchManager().getMatch().getWorld(), block.getX(), block.getY(), block.getZ()))) results.add(block);
+            if (contains(block)) results.add(block);
         }
         return results;
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/wool/WoolObjective.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/wool/WoolObjective.java
@@ -64,10 +64,10 @@ public class WoolObjective implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlace(BlockPlaceEvent event) {
         if (event.getBlockPlaced().getType() == block) {
-            if (!completed && podium.contains(event.getBlockPlaced().getLocation()) && owner.containsPlayer(event.getPlayer()))
+            if (!completed && podium.contains(event.getBlockPlaced()) && owner.containsPlayer(event.getPlayer()))
                 event.setCancelled(true);
         } else {
-            if (podium.contains(event.getBlockPlaced().getLocation())) {
+            if (podium.contains(event.getBlockPlaced())) {
                 event.setCancelled(true);
                 event.getPlayer().sendMessage(ChatColor.RED + "You may only place " + ChatColor.YELLOW + ItemUtils.materialToString(block) + ChatColor.RED + " in the podium!");
             }
@@ -80,7 +80,7 @@ public class WoolObjective implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlaceHighest(BlockPlaceEvent event) {
         if (!completed && event.getBlockPlaced().getType() == block) {
-            if (!podium.contains(event.getBlockPlaced().getLocation())) {
+            if (!podium.contains(event.getBlockPlaced())) {
                 return;
             }
             if (!owner.containsPlayer(event.getPlayer())) {


### PR DESCRIPTION
These changes do not change any game mechanics at all, but will be necessary for the upcoming block containment checking conversion from block positions to coordinates. It will make the final conversion PR a lot more smaller and readable. For the conversion to take effect after this PR, the only changes left have to be done in the individual Region.contains(Block block) methods.

Tested.

Important note: I made changes to the cylinder/(hemi)sphere classes getBlocks() methods to remove redundant code, however, I'm unsure if there was an actual intention behind that code. The only usage for getBlocks() is found in portals, which I tested and still worked.